### PR TITLE
[GH-9] - additional information added to "Unused Received" diagnostic

### DIFF
--- a/src/NSubstitute.Analyzers.CSharp/Resources.Designer.cs
+++ b/src/NSubstitute.Analyzers.CSharp/Resources.Designer.cs
@@ -20,7 +20,7 @@ namespace NSubstitute.Analyzers.CSharp {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {
@@ -99,6 +99,33 @@ namespace NSubstitute.Analyzers.CSharp {
         
         /// <summary>
         ///   Looks up a localized string similar to Unused received check..
+        /// </summary>
+        internal static string UnusedReceivedForOrdinaryMethodDescription {
+            get {
+                return ResourceManager.GetString("UnusedReceivedForOrdinaryMethodDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Unused received check. To fix, make sure there is a call after &quot;{0}&quot;. Correct: &quot;SubstituteExtensions.{0}(sub).SomeCall();&quot;. Incorrect: &quot;SubstituteExtensions.{0}(sub);&quot;.
+        /// </summary>
+        internal static string UnusedReceivedForOrdinaryMethodMessageFormat {
+            get {
+                return ResourceManager.GetString("UnusedReceivedForOrdinaryMethodMessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Received check..
+        /// </summary>
+        internal static string UnusedReceivedForOrdinaryMethodTitle {
+            get {
+                return ResourceManager.GetString("UnusedReceivedForOrdinaryMethodTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Unused received check. To fix, make sure there is a call after &quot;{0}&quot;. Correct: &quot;sub.{0}().SomeCall();&quot;. Incorrect: &quot;sub.{0}();&quot;.
         /// </summary>
         internal static string UnusedReceivedMessageFormat {
             get {

--- a/src/NSubstitute.Analyzers.CSharp/Resources.resx
+++ b/src/NSubstitute.Analyzers.CSharp/Resources.resx
@@ -134,10 +134,22 @@
     <comment>An optional longer localizable description of the diagnostic.</comment>
   </data>
   <data name="UnusedReceivedMessageFormat" xml:space="preserve">
-    <value>Unused received check.</value>
+    <value>Unused received check. To fix, make sure there is a call after "{0}". Correct: "sub.{0}().SomeCall();". Incorrect: "sub.{0}();"</value>
     <comment>The format-able message the diagnostic displays.</comment>
   </data>
   <data name="UnusedReceivedTitle" xml:space="preserve">
+    <value>Received check.</value>
+    <comment>The title of the diagnostic.</comment>
+  </data>
+  <data name="UnusedReceivedForOrdinaryMethodDescription" xml:space="preserve">
+    <value>Unused received check.</value>
+    <comment>An optional longer localizable description of the diagnostic.</comment>
+  </data>
+  <data name="UnusedReceivedForOrdinaryMethodMessageFormat" xml:space="preserve">
+    <value>Unused received check. To fix, make sure there is a call after "{0}". Correct: "SubstituteExtensions.{0}(sub).SomeCall();". Incorrect: "SubstituteExtensions.{0}(sub);"</value>
+    <comment>The format-able message the diagnostic displays.</comment>
+  </data>
+  <data name="UnusedReceivedForOrdinaryMethodTitle" xml:space="preserve">
     <value>Received check.</value>
     <comment>The title of the diagnostic.</comment>
   </data>

--- a/src/NSubstitute.Analyzers.Shared/AbstractDiagnosticDescriptorsProvider.cs
+++ b/src/NSubstitute.Analyzers.Shared/AbstractDiagnosticDescriptorsProvider.cs
@@ -7,5 +7,7 @@ namespace NSubstitute.Analyzers.Shared
         public DiagnosticDescriptor NonVirtualSetupSpecification { get; } = DiagnosticDescriptors<T>.NonVirtualSetupSpecification;
 
         public DiagnosticDescriptor UnusedReceived { get; } = DiagnosticDescriptors<T>.UnusedReceived;
+
+        public DiagnosticDescriptor UnusedReceivedForOrdinaryMethod { get; } = DiagnosticDescriptors<T>.UnusedReceivedForOrdinaryMethod;
     }
 }

--- a/src/NSubstitute.Analyzers.Shared/DiagnosticAnalyzers/AbstractUnusedReceivedAnalyzer.cs
+++ b/src/NSubstitute.Analyzers.Shared/DiagnosticAnalyzers/AbstractUnusedReceivedAnalyzer.cs
@@ -61,8 +61,12 @@ namespace NSubstitute.Analyzers.Shared.DiagnosticAnalyzers
                 return;
             }
 
+            var diagnosticDescriptor = methodSymbol.MethodKind == MethodKind.Ordinary
+                ? DiagnosticDescriptorsProvider.UnusedReceivedForOrdinaryMethod
+                : DiagnosticDescriptorsProvider.UnusedReceived;
+
             var diagnostic = Diagnostic.Create(
-                DiagnosticDescriptorsProvider.UnusedReceived,
+                diagnosticDescriptor,
                 invocationExpression.GetLocation(),
                 methodSymbol.Name);
 

--- a/src/NSubstitute.Analyzers.Shared/DiagnosticDescriptors.cs
+++ b/src/NSubstitute.Analyzers.Shared/DiagnosticDescriptors.cs
@@ -27,6 +27,14 @@ namespace NSubstitute.Analyzers.Shared
                 defaultSeverity: DiagnosticSeverity.Warning,
                 isEnabledByDefault: true);
 
+        public static DiagnosticDescriptor UnusedReceivedForOrdinaryMethod { get; } =
+            CreateDiagnosticDescriptor(
+                name: nameof(UnusedReceivedForOrdinaryMethod),
+                id: DiagnosticIdentifiers.UnusedReceived,
+                category: DiagnosticCategories.Usage,
+                defaultSeverity: DiagnosticSeverity.Warning,
+                isEnabledByDefault: true);
+
         private static DiagnosticDescriptor CreateDiagnosticDescriptor(
             string name, string id, string category, DiagnosticSeverity defaultSeverity, bool isEnabledByDefault)
         {

--- a/src/NSubstitute.Analyzers.Shared/IDiagnosticDescriptorsProvider.cs
+++ b/src/NSubstitute.Analyzers.Shared/IDiagnosticDescriptorsProvider.cs
@@ -7,5 +7,7 @@ namespace NSubstitute.Analyzers.Shared
         DiagnosticDescriptor NonVirtualSetupSpecification { get; }
 
         DiagnosticDescriptor UnusedReceived { get; }
+
+        DiagnosticDescriptor UnusedReceivedForOrdinaryMethod { get; }
     }
 }

--- a/src/NSubstitute.Analyzers.VisualBasic/Resources.Designer.cs
+++ b/src/NSubstitute.Analyzers.VisualBasic/Resources.Designer.cs
@@ -20,7 +20,7 @@ namespace NSubstitute.Analyzers.VisualBasic {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {
@@ -99,6 +99,33 @@ namespace NSubstitute.Analyzers.VisualBasic {
         
         /// <summary>
         ///   Looks up a localized string similar to Unused received check..
+        /// </summary>
+        internal static string UnusedReceivedForOrdinaryMethodDescription {
+            get {
+                return ResourceManager.GetString("UnusedReceivedForOrdinaryMethodDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Unused received check. To fix, make sure there is a call after &quot;{0}&quot;. Correct: &quot;SubstituteExtensions.{0}(sub).SomeCall();&quot;. Incorrect: &quot;SubstituteExtensions.{0}(sub);&quot;.
+        /// </summary>
+        internal static string UnusedReceivedForOrdinaryMethodMessageFormat {
+            get {
+                return ResourceManager.GetString("UnusedReceivedForOrdinaryMethodMessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Received check..
+        /// </summary>
+        internal static string UnusedReceivedForOrdinaryMethodTitle {
+            get {
+                return ResourceManager.GetString("UnusedReceivedForOrdinaryMethodTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Unused received check. To fix, make sure there is a call after &quot;{0}&quot;. Correct: &quot;sub.{0}().SomeCall();&quot;. Incorrect: &quot;sub.{0}();&quot;.
         /// </summary>
         internal static string UnusedReceivedMessageFormat {
             get {

--- a/src/NSubstitute.Analyzers.VisualBasic/Resources.resx
+++ b/src/NSubstitute.Analyzers.VisualBasic/Resources.resx
@@ -134,10 +134,22 @@
     <comment>An optional longer localizable description of the diagnostic.</comment>
   </data>
   <data name="UnusedReceivedMessageFormat" xml:space="preserve">
-    <value>Unused received check.</value>
+    <value>Unused received check. To fix, make sure there is a call after "{0}". Correct: "sub.{0}().SomeCall();". Incorrect: "sub.{0}();"</value>
     <comment>The format-able message the diagnostic displays.</comment>
   </data>
   <data name="UnusedReceivedTitle" xml:space="preserve">
+    <value>Received check.</value>
+    <comment>The title of the diagnostic.</comment>
+  </data>
+    <data name="UnusedReceivedForOrdinaryMethodDescription" xml:space="preserve">
+    <value>Unused received check.</value>
+    <comment>An optional longer localizable description of the diagnostic.</comment>
+  </data>
+  <data name="UnusedReceivedForOrdinaryMethodMessageFormat" xml:space="preserve">
+    <value>Unused received check. To fix, make sure there is a call after "{0}". Correct: "SubstituteExtensions.{0}(sub).SomeCall();". Incorrect: "SubstituteExtensions.{0}(sub);"</value>
+    <comment>The format-able message the diagnostic displays.</comment>
+  </data>
+  <data name="UnusedReceivedForOrdinaryMethodTitle" xml:space="preserve">
     <value>Received check.</value>
     <comment>The title of the diagnostic.</comment>
   </data>

--- a/tests/NSubstitute.Analyzers.Tests.CSharp/DiagnosticAnalyzerTests/UnusedReceivedAnalyzerTests/DidNotReceiveAsExtensionMethodTests.cs
+++ b/tests/NSubstitute.Analyzers.Tests.CSharp/DiagnosticAnalyzerTests/UnusedReceivedAnalyzerTests/DidNotReceiveAsExtensionMethodTests.cs
@@ -30,7 +30,7 @@ namespace MyNamespace
             {
                 Id = DiagnosticIdentifiers.UnusedReceived,
                 Severity = DiagnosticSeverity.Warning,
-                Message = "Unused received check.",
+                Message = @"Unused received check. To fix, make sure there is a call after ""DidNotReceive"". Correct: ""sub.DidNotReceive().SomeCall();"". Incorrect: ""sub.DidNotReceive();""",
                 Locations = new[]
                 {
                     new DiagnosticResultLocation(14, 13)

--- a/tests/NSubstitute.Analyzers.Tests.CSharp/DiagnosticAnalyzerTests/UnusedReceivedAnalyzerTests/DidNotReceiveAsExtensionMethodWithGenericTypeSpecifiedTests.cs
+++ b/tests/NSubstitute.Analyzers.Tests.CSharp/DiagnosticAnalyzerTests/UnusedReceivedAnalyzerTests/DidNotReceiveAsExtensionMethodWithGenericTypeSpecifiedTests.cs
@@ -30,7 +30,7 @@ namespace MyNamespace
             {
                 Id = DiagnosticIdentifiers.UnusedReceived,
                 Severity = DiagnosticSeverity.Warning,
-                Message = "Unused received check.",
+                Message = @"Unused received check. To fix, make sure there is a call after ""DidNotReceive"". Correct: ""sub.DidNotReceive().SomeCall();"". Incorrect: ""sub.DidNotReceive();""",
                 Locations = new[]
                 {
                     new DiagnosticResultLocation(14, 13)

--- a/tests/NSubstitute.Analyzers.Tests.CSharp/DiagnosticAnalyzerTests/UnusedReceivedAnalyzerTests/DidNotReceiveAsOrdinaryMethodTests.cs
+++ b/tests/NSubstitute.Analyzers.Tests.CSharp/DiagnosticAnalyzerTests/UnusedReceivedAnalyzerTests/DidNotReceiveAsOrdinaryMethodTests.cs
@@ -30,7 +30,7 @@ namespace MyNamespace
             {
                 Id = DiagnosticIdentifiers.UnusedReceived,
                 Severity = DiagnosticSeverity.Warning,
-                Message = "Unused received check.",
+                Message = @"Unused received check. To fix, make sure there is a call after ""DidNotReceive"". Correct: ""SubstituteExtensions.DidNotReceive(sub).SomeCall();"". Incorrect: ""SubstituteExtensions.DidNotReceive(sub);""",
                 Locations = new[]
                 {
                     new DiagnosticResultLocation(14, 13)

--- a/tests/NSubstitute.Analyzers.Tests.CSharp/DiagnosticAnalyzerTests/UnusedReceivedAnalyzerTests/DidNotReceiveAsOrdinaryMethodWithGenericTypeSpecifiedTests.cs
+++ b/tests/NSubstitute.Analyzers.Tests.CSharp/DiagnosticAnalyzerTests/UnusedReceivedAnalyzerTests/DidNotReceiveAsOrdinaryMethodWithGenericTypeSpecifiedTests.cs
@@ -30,7 +30,7 @@ namespace MyNamespace
             {
                 Id = DiagnosticIdentifiers.UnusedReceived,
                 Severity = DiagnosticSeverity.Warning,
-                Message = "Unused received check.",
+                Message = @"Unused received check. To fix, make sure there is a call after ""DidNotReceive"". Correct: ""SubstituteExtensions.DidNotReceive(sub).SomeCall();"". Incorrect: ""SubstituteExtensions.DidNotReceive(sub);""",
                 Locations = new[]
                 {
                     new DiagnosticResultLocation(14, 13)

--- a/tests/NSubstitute.Analyzers.Tests.CSharp/DiagnosticAnalyzerTests/UnusedReceivedAnalyzerTests/DidNotReceiveWithAnyArgsAsExtensionMethodTests.cs
+++ b/tests/NSubstitute.Analyzers.Tests.CSharp/DiagnosticAnalyzerTests/UnusedReceivedAnalyzerTests/DidNotReceiveWithAnyArgsAsExtensionMethodTests.cs
@@ -30,7 +30,7 @@ namespace MyNamespace
             {
                 Id = DiagnosticIdentifiers.UnusedReceived,
                 Severity = DiagnosticSeverity.Warning,
-                Message = "Unused received check.",
+                Message = @"Unused received check. To fix, make sure there is a call after ""DidNotReceiveWithAnyArgs"". Correct: ""sub.DidNotReceiveWithAnyArgs().SomeCall();"". Incorrect: ""sub.DidNotReceiveWithAnyArgs();""",
                 Locations = new[]
                 {
                     new DiagnosticResultLocation(14, 13)

--- a/tests/NSubstitute.Analyzers.Tests.CSharp/DiagnosticAnalyzerTests/UnusedReceivedAnalyzerTests/DidNotReceiveWithAnyArgsAsExtensionMethodWithGenericTypeSpecifiedTests.cs
+++ b/tests/NSubstitute.Analyzers.Tests.CSharp/DiagnosticAnalyzerTests/UnusedReceivedAnalyzerTests/DidNotReceiveWithAnyArgsAsExtensionMethodWithGenericTypeSpecifiedTests.cs
@@ -30,7 +30,7 @@ namespace MyNamespace
             {
                 Id = DiagnosticIdentifiers.UnusedReceived,
                 Severity = DiagnosticSeverity.Warning,
-                Message = "Unused received check.",
+                Message = @"Unused received check. To fix, make sure there is a call after ""DidNotReceiveWithAnyArgs"". Correct: ""sub.DidNotReceiveWithAnyArgs().SomeCall();"". Incorrect: ""sub.DidNotReceiveWithAnyArgs();""",
                 Locations = new[]
                 {
                     new DiagnosticResultLocation(14, 13)

--- a/tests/NSubstitute.Analyzers.Tests.CSharp/DiagnosticAnalyzerTests/UnusedReceivedAnalyzerTests/DidNotReceiveWithAnyArgsAsOrdinaryMethodTests.cs
+++ b/tests/NSubstitute.Analyzers.Tests.CSharp/DiagnosticAnalyzerTests/UnusedReceivedAnalyzerTests/DidNotReceiveWithAnyArgsAsOrdinaryMethodTests.cs
@@ -30,7 +30,7 @@ namespace MyNamespace
             {
                 Id = DiagnosticIdentifiers.UnusedReceived,
                 Severity = DiagnosticSeverity.Warning,
-                Message = "Unused received check.",
+                Message = @"Unused received check. To fix, make sure there is a call after ""DidNotReceiveWithAnyArgs"". Correct: ""SubstituteExtensions.DidNotReceiveWithAnyArgs(sub).SomeCall();"". Incorrect: ""SubstituteExtensions.DidNotReceiveWithAnyArgs(sub);""",
                 Locations = new[]
                 {
                     new DiagnosticResultLocation(14, 13)

--- a/tests/NSubstitute.Analyzers.Tests.CSharp/DiagnosticAnalyzerTests/UnusedReceivedAnalyzerTests/DidNotReceiveWithAnyArgsAsOrdinaryMethodWithGenericTypeSpecifiedTests.cs
+++ b/tests/NSubstitute.Analyzers.Tests.CSharp/DiagnosticAnalyzerTests/UnusedReceivedAnalyzerTests/DidNotReceiveWithAnyArgsAsOrdinaryMethodWithGenericTypeSpecifiedTests.cs
@@ -30,7 +30,7 @@ namespace MyNamespace
             {
                 Id = DiagnosticIdentifiers.UnusedReceived,
                 Severity = DiagnosticSeverity.Warning,
-                Message = "Unused received check.",
+                Message = @"Unused received check. To fix, make sure there is a call after ""DidNotReceiveWithAnyArgs"". Correct: ""SubstituteExtensions.DidNotReceiveWithAnyArgs(sub).SomeCall();"". Incorrect: ""SubstituteExtensions.DidNotReceiveWithAnyArgs(sub);""",
                 Locations = new[]
                 {
                     new DiagnosticResultLocation(14, 13)

--- a/tests/NSubstitute.Analyzers.Tests.CSharp/DiagnosticAnalyzerTests/UnusedReceivedAnalyzerTests/ReceivedAsExtensionMethodTests.cs
+++ b/tests/NSubstitute.Analyzers.Tests.CSharp/DiagnosticAnalyzerTests/UnusedReceivedAnalyzerTests/ReceivedAsExtensionMethodTests.cs
@@ -30,7 +30,7 @@ namespace MyNamespace
             {
                 Id = DiagnosticIdentifiers.UnusedReceived,
                 Severity = DiagnosticSeverity.Warning,
-                Message = "Unused received check.",
+                Message = @"Unused received check. To fix, make sure there is a call after ""Received"". Correct: ""sub.Received().SomeCall();"". Incorrect: ""sub.Received();""",
                 Locations = new[]
                 {
                     new DiagnosticResultLocation(14, 13)

--- a/tests/NSubstitute.Analyzers.Tests.CSharp/DiagnosticAnalyzerTests/UnusedReceivedAnalyzerTests/ReceivedAsExtensionMethodWithGenericTypeSpecifiedTests.cs
+++ b/tests/NSubstitute.Analyzers.Tests.CSharp/DiagnosticAnalyzerTests/UnusedReceivedAnalyzerTests/ReceivedAsExtensionMethodWithGenericTypeSpecifiedTests.cs
@@ -30,7 +30,7 @@ namespace MyNamespace
             {
                 Id = DiagnosticIdentifiers.UnusedReceived,
                 Severity = DiagnosticSeverity.Warning,
-                Message = "Unused received check.",
+                Message = @"Unused received check. To fix, make sure there is a call after ""Received"". Correct: ""sub.Received().SomeCall();"". Incorrect: ""sub.Received();""",
                 Locations = new[]
                 {
                     new DiagnosticResultLocation(14, 13)

--- a/tests/NSubstitute.Analyzers.Tests.CSharp/DiagnosticAnalyzerTests/UnusedReceivedAnalyzerTests/ReceivedAsOrdinaryMethodTests.cs
+++ b/tests/NSubstitute.Analyzers.Tests.CSharp/DiagnosticAnalyzerTests/UnusedReceivedAnalyzerTests/ReceivedAsOrdinaryMethodTests.cs
@@ -30,7 +30,7 @@ namespace MyNamespace
             {
                 Id = DiagnosticIdentifiers.UnusedReceived,
                 Severity = DiagnosticSeverity.Warning,
-                Message = "Unused received check.",
+                Message = @"Unused received check. To fix, make sure there is a call after ""Received"". Correct: ""SubstituteExtensions.Received(sub).SomeCall();"". Incorrect: ""SubstituteExtensions.Received(sub);""",
                 Locations = new[]
                 {
                     new DiagnosticResultLocation(14, 13)

--- a/tests/NSubstitute.Analyzers.Tests.CSharp/DiagnosticAnalyzerTests/UnusedReceivedAnalyzerTests/ReceivedAsOrdinaryMethodWithGenericTypeSpecifiedTests.cs
+++ b/tests/NSubstitute.Analyzers.Tests.CSharp/DiagnosticAnalyzerTests/UnusedReceivedAnalyzerTests/ReceivedAsOrdinaryMethodWithGenericTypeSpecifiedTests.cs
@@ -30,7 +30,7 @@ namespace MyNamespace
             {
                 Id = DiagnosticIdentifiers.UnusedReceived,
                 Severity = DiagnosticSeverity.Warning,
-                Message = "Unused received check.",
+                Message = @"Unused received check. To fix, make sure there is a call after ""Received"". Correct: ""SubstituteExtensions.Received(sub).SomeCall();"". Incorrect: ""SubstituteExtensions.Received(sub);""",
                 Locations = new[]
                 {
                     new DiagnosticResultLocation(14, 13)

--- a/tests/NSubstitute.Analyzers.Tests.CSharp/DiagnosticAnalyzerTests/UnusedReceivedAnalyzerTests/ReceivedWithAnyArgsAsExtensionMethodTests.cs
+++ b/tests/NSubstitute.Analyzers.Tests.CSharp/DiagnosticAnalyzerTests/UnusedReceivedAnalyzerTests/ReceivedWithAnyArgsAsExtensionMethodTests.cs
@@ -30,7 +30,7 @@ namespace MyNamespace
             {
                 Id = DiagnosticIdentifiers.UnusedReceived,
                 Severity = DiagnosticSeverity.Warning,
-                Message = "Unused received check.",
+                Message = @"Unused received check. To fix, make sure there is a call after ""ReceivedWithAnyArgs"". Correct: ""sub.ReceivedWithAnyArgs().SomeCall();"". Incorrect: ""sub.ReceivedWithAnyArgs();""",
                 Locations = new[]
                 {
                     new DiagnosticResultLocation(14, 13)

--- a/tests/NSubstitute.Analyzers.Tests.CSharp/DiagnosticAnalyzerTests/UnusedReceivedAnalyzerTests/ReceivedWithAnyArgsAsExtensionMethodWithGenericTypeSpecifiedTests.cs
+++ b/tests/NSubstitute.Analyzers.Tests.CSharp/DiagnosticAnalyzerTests/UnusedReceivedAnalyzerTests/ReceivedWithAnyArgsAsExtensionMethodWithGenericTypeSpecifiedTests.cs
@@ -30,7 +30,7 @@ namespace MyNamespace
             {
                 Id = DiagnosticIdentifiers.UnusedReceived,
                 Severity = DiagnosticSeverity.Warning,
-                Message = "Unused received check.",
+                Message = @"Unused received check. To fix, make sure there is a call after ""ReceivedWithAnyArgs"". Correct: ""sub.ReceivedWithAnyArgs().SomeCall();"". Incorrect: ""sub.ReceivedWithAnyArgs();""",
                 Locations = new[]
                 {
                     new DiagnosticResultLocation(14, 13)

--- a/tests/NSubstitute.Analyzers.Tests.CSharp/DiagnosticAnalyzerTests/UnusedReceivedAnalyzerTests/ReceivedWithAnyArgsAsOrdinaryMethodTests.cs
+++ b/tests/NSubstitute.Analyzers.Tests.CSharp/DiagnosticAnalyzerTests/UnusedReceivedAnalyzerTests/ReceivedWithAnyArgsAsOrdinaryMethodTests.cs
@@ -30,7 +30,7 @@ namespace MyNamespace
             {
                 Id = DiagnosticIdentifiers.UnusedReceived,
                 Severity = DiagnosticSeverity.Warning,
-                Message = "Unused received check.",
+                Message = @"Unused received check. To fix, make sure there is a call after ""ReceivedWithAnyArgs"". Correct: ""SubstituteExtensions.ReceivedWithAnyArgs(sub).SomeCall();"". Incorrect: ""SubstituteExtensions.ReceivedWithAnyArgs(sub);""",
                 Locations = new[]
                 {
                     new DiagnosticResultLocation(14, 13)

--- a/tests/NSubstitute.Analyzers.Tests.CSharp/DiagnosticAnalyzerTests/UnusedReceivedAnalyzerTests/ReceivedWithAnyArgsAsOrdinaryMethodWithGenericTypeSpecifiedTests.cs
+++ b/tests/NSubstitute.Analyzers.Tests.CSharp/DiagnosticAnalyzerTests/UnusedReceivedAnalyzerTests/ReceivedWithAnyArgsAsOrdinaryMethodWithGenericTypeSpecifiedTests.cs
@@ -30,7 +30,7 @@ namespace MyNamespace
             {
                 Id = DiagnosticIdentifiers.UnusedReceived,
                 Severity = DiagnosticSeverity.Warning,
-                Message = "Unused received check.",
+                Message = @"Unused received check. To fix, make sure there is a call after ""ReceivedWithAnyArgs"". Correct: ""SubstituteExtensions.ReceivedWithAnyArgs(sub).SomeCall();"". Incorrect: ""SubstituteExtensions.ReceivedWithAnyArgs(sub);""",
                 Locations = new[]
                 {
                     new DiagnosticResultLocation(14, 13)

--- a/tests/NSubstitute.Analyzers.Tests.VisualBasic/DiagnosticAnalyzerTests/UnusedReceivedAnalyzerTests/DidNotReceiveAsExtensionMethodTests.cs
+++ b/tests/NSubstitute.Analyzers.Tests.VisualBasic/DiagnosticAnalyzerTests/UnusedReceivedAnalyzerTests/DidNotReceiveAsExtensionMethodTests.cs
@@ -27,7 +27,7 @@ End Namespace
             {
                 Id = DiagnosticIdentifiers.UnusedReceived,
                 Severity = DiagnosticSeverity.Warning,
-                Message = "Unused received check.",
+                Message = @"Unused received check. To fix, make sure there is a call after ""DidNotReceive"". Correct: ""sub.DidNotReceive().SomeCall();"". Incorrect: ""sub.DidNotReceive();""",
                 Locations = new[]
                 {
                     new DiagnosticResultLocation(10, 13)

--- a/tests/NSubstitute.Analyzers.Tests.VisualBasic/DiagnosticAnalyzerTests/UnusedReceivedAnalyzerTests/DidNotReceiveAsOrdinaryMethodTests.cs
+++ b/tests/NSubstitute.Analyzers.Tests.VisualBasic/DiagnosticAnalyzerTests/UnusedReceivedAnalyzerTests/DidNotReceiveAsOrdinaryMethodTests.cs
@@ -27,7 +27,7 @@ End Namespace
             {
                 Id = DiagnosticIdentifiers.UnusedReceived,
                 Severity = DiagnosticSeverity.Warning,
-                Message = "Unused received check.",
+                Message = @"Unused received check. To fix, make sure there is a call after ""DidNotReceive"". Correct: ""SubstituteExtensions.DidNotReceive(sub).SomeCall();"". Incorrect: ""SubstituteExtensions.DidNotReceive(sub);""",
                 Locations = new[]
                 {
                     new DiagnosticResultLocation(10, 13)

--- a/tests/NSubstitute.Analyzers.Tests.VisualBasic/DiagnosticAnalyzerTests/UnusedReceivedAnalyzerTests/DidNotReceiveAsOrdinaryMethodWithGenericTypeSpecifiedTests.cs
+++ b/tests/NSubstitute.Analyzers.Tests.VisualBasic/DiagnosticAnalyzerTests/UnusedReceivedAnalyzerTests/DidNotReceiveAsOrdinaryMethodWithGenericTypeSpecifiedTests.cs
@@ -27,7 +27,7 @@ End Namespace
             {
                 Id = DiagnosticIdentifiers.UnusedReceived,
                 Severity = DiagnosticSeverity.Warning,
-                Message = "Unused received check.",
+                Message = @"Unused received check. To fix, make sure there is a call after ""DidNotReceive"". Correct: ""SubstituteExtensions.DidNotReceive(sub).SomeCall();"". Incorrect: ""SubstituteExtensions.DidNotReceive(sub);""",
                 Locations = new[]
                 {
                     new DiagnosticResultLocation(10, 13)

--- a/tests/NSubstitute.Analyzers.Tests.VisualBasic/DiagnosticAnalyzerTests/UnusedReceivedAnalyzerTests/DidNotReceiveWithAnyArgsAsExtensionMethodTests.cs
+++ b/tests/NSubstitute.Analyzers.Tests.VisualBasic/DiagnosticAnalyzerTests/UnusedReceivedAnalyzerTests/DidNotReceiveWithAnyArgsAsExtensionMethodTests.cs
@@ -27,7 +27,7 @@ End Namespace
             {
                 Id = DiagnosticIdentifiers.UnusedReceived,
                 Severity = DiagnosticSeverity.Warning,
-                Message = "Unused received check.",
+                Message = @"Unused received check. To fix, make sure there is a call after ""DidNotReceiveWithAnyArgs"". Correct: ""sub.DidNotReceiveWithAnyArgs().SomeCall();"". Incorrect: ""sub.DidNotReceiveWithAnyArgs();""",
                 Locations = new[]
                 {
                     new DiagnosticResultLocation(10, 13)

--- a/tests/NSubstitute.Analyzers.Tests.VisualBasic/DiagnosticAnalyzerTests/UnusedReceivedAnalyzerTests/DidNotReceiveWithAnyArgsAsOrdinaryMethodTests.cs
+++ b/tests/NSubstitute.Analyzers.Tests.VisualBasic/DiagnosticAnalyzerTests/UnusedReceivedAnalyzerTests/DidNotReceiveWithAnyArgsAsOrdinaryMethodTests.cs
@@ -27,7 +27,7 @@ End Namespace
             {
                 Id = DiagnosticIdentifiers.UnusedReceived,
                 Severity = DiagnosticSeverity.Warning,
-                Message = "Unused received check.",
+                Message = @"Unused received check. To fix, make sure there is a call after ""DidNotReceiveWithAnyArgs"". Correct: ""SubstituteExtensions.DidNotReceiveWithAnyArgs(sub).SomeCall();"". Incorrect: ""SubstituteExtensions.DidNotReceiveWithAnyArgs(sub);""",
                 Locations = new[]
                 {
                     new DiagnosticResultLocation(10, 13)

--- a/tests/NSubstitute.Analyzers.Tests.VisualBasic/DiagnosticAnalyzerTests/UnusedReceivedAnalyzerTests/DidNotReceiveWithAnyArgsAsOrdinaryMethodWithGenericTypeSpecifiedTests.cs
+++ b/tests/NSubstitute.Analyzers.Tests.VisualBasic/DiagnosticAnalyzerTests/UnusedReceivedAnalyzerTests/DidNotReceiveWithAnyArgsAsOrdinaryMethodWithGenericTypeSpecifiedTests.cs
@@ -27,7 +27,7 @@ End Namespace
             {
                 Id = DiagnosticIdentifiers.UnusedReceived,
                 Severity = DiagnosticSeverity.Warning,
-                Message = "Unused received check.",
+                Message = @"Unused received check. To fix, make sure there is a call after ""DidNotReceiveWithAnyArgs"". Correct: ""SubstituteExtensions.DidNotReceiveWithAnyArgs(sub).SomeCall();"". Incorrect: ""SubstituteExtensions.DidNotReceiveWithAnyArgs(sub);""",
                 Locations = new[]
                 {
                     new DiagnosticResultLocation(10, 13)

--- a/tests/NSubstitute.Analyzers.Tests.VisualBasic/DiagnosticAnalyzerTests/UnusedReceivedAnalyzerTests/ReceivedAsExtensionMethodTests.cs
+++ b/tests/NSubstitute.Analyzers.Tests.VisualBasic/DiagnosticAnalyzerTests/UnusedReceivedAnalyzerTests/ReceivedAsExtensionMethodTests.cs
@@ -27,7 +27,7 @@ End Namespace
             {
                 Id = DiagnosticIdentifiers.UnusedReceived,
                 Severity = DiagnosticSeverity.Warning,
-                Message = "Unused received check.",
+                Message = @"Unused received check. To fix, make sure there is a call after ""Received"". Correct: ""sub.Received().SomeCall();"". Incorrect: ""sub.Received();""",
                 Locations = new[]
                 {
                     new DiagnosticResultLocation(10, 13)

--- a/tests/NSubstitute.Analyzers.Tests.VisualBasic/DiagnosticAnalyzerTests/UnusedReceivedAnalyzerTests/ReceivedAsOrdinaryMethodTests.cs
+++ b/tests/NSubstitute.Analyzers.Tests.VisualBasic/DiagnosticAnalyzerTests/UnusedReceivedAnalyzerTests/ReceivedAsOrdinaryMethodTests.cs
@@ -27,7 +27,7 @@ End Namespace
             {
                 Id = DiagnosticIdentifiers.UnusedReceived,
                 Severity = DiagnosticSeverity.Warning,
-                Message = "Unused received check.",
+                Message = @"Unused received check. To fix, make sure there is a call after ""Received"". Correct: ""SubstituteExtensions.Received(sub).SomeCall();"". Incorrect: ""SubstituteExtensions.Received(sub);""",
                 Locations = new[]
                 {
                     new DiagnosticResultLocation(10, 13)

--- a/tests/NSubstitute.Analyzers.Tests.VisualBasic/DiagnosticAnalyzerTests/UnusedReceivedAnalyzerTests/ReceivedAsOrdinaryMethodWithGenericTypeSpecifiedTests.cs
+++ b/tests/NSubstitute.Analyzers.Tests.VisualBasic/DiagnosticAnalyzerTests/UnusedReceivedAnalyzerTests/ReceivedAsOrdinaryMethodWithGenericTypeSpecifiedTests.cs
@@ -27,7 +27,7 @@ End Namespace
             {
                 Id = DiagnosticIdentifiers.UnusedReceived,
                 Severity = DiagnosticSeverity.Warning,
-                Message = "Unused received check.",
+                Message = @"Unused received check. To fix, make sure there is a call after ""Received"". Correct: ""SubstituteExtensions.Received(sub).SomeCall();"". Incorrect: ""SubstituteExtensions.Received(sub);""",
                 Locations = new[]
                 {
                     new DiagnosticResultLocation(10, 13)

--- a/tests/NSubstitute.Analyzers.Tests.VisualBasic/DiagnosticAnalyzerTests/UnusedReceivedAnalyzerTests/ReceivedWithAnyArgsAsExtensionMethodTests.cs
+++ b/tests/NSubstitute.Analyzers.Tests.VisualBasic/DiagnosticAnalyzerTests/UnusedReceivedAnalyzerTests/ReceivedWithAnyArgsAsExtensionMethodTests.cs
@@ -27,7 +27,7 @@ End Namespace
             {
                 Id = DiagnosticIdentifiers.UnusedReceived,
                 Severity = DiagnosticSeverity.Warning,
-                Message = "Unused received check.",
+                Message = @"Unused received check. To fix, make sure there is a call after ""ReceivedWithAnyArgs"". Correct: ""sub.ReceivedWithAnyArgs().SomeCall();"". Incorrect: ""sub.ReceivedWithAnyArgs();""",
                 Locations = new[]
                 {
                     new DiagnosticResultLocation(10, 13)

--- a/tests/NSubstitute.Analyzers.Tests.VisualBasic/DiagnosticAnalyzerTests/UnusedReceivedAnalyzerTests/ReceivedWithAnyArgsAsOrdinaryMethodTests.cs
+++ b/tests/NSubstitute.Analyzers.Tests.VisualBasic/DiagnosticAnalyzerTests/UnusedReceivedAnalyzerTests/ReceivedWithAnyArgsAsOrdinaryMethodTests.cs
@@ -27,7 +27,7 @@ End Namespace
             {
                 Id = DiagnosticIdentifiers.UnusedReceived,
                 Severity = DiagnosticSeverity.Warning,
-                Message = "Unused received check.",
+                Message = @"Unused received check. To fix, make sure there is a call after ""ReceivedWithAnyArgs"". Correct: ""SubstituteExtensions.ReceivedWithAnyArgs(sub).SomeCall();"". Incorrect: ""SubstituteExtensions.ReceivedWithAnyArgs(sub);""",
                 Locations = new[]
                 {
                     new DiagnosticResultLocation(10, 13)

--- a/tests/NSubstitute.Analyzers.Tests.VisualBasic/DiagnosticAnalyzerTests/UnusedReceivedAnalyzerTests/ReceivedWithAnyArgsAsOrdinaryMethodWithGenericTypeSpecifiedTests.cs
+++ b/tests/NSubstitute.Analyzers.Tests.VisualBasic/DiagnosticAnalyzerTests/UnusedReceivedAnalyzerTests/ReceivedWithAnyArgsAsOrdinaryMethodWithGenericTypeSpecifiedTests.cs
@@ -27,7 +27,7 @@ End Namespace
             {
                 Id = DiagnosticIdentifiers.UnusedReceived,
                 Severity = DiagnosticSeverity.Warning,
-                Message = "Unused received check.",
+                Message = @"Unused received check. To fix, make sure there is a call after ""ReceivedWithAnyArgs"". Correct: ""SubstituteExtensions.ReceivedWithAnyArgs(sub).SomeCall();"". Incorrect: ""SubstituteExtensions.ReceivedWithAnyArgs(sub);""",
                 Locations = new[]
                 {
                     new DiagnosticResultLocation(10, 13)


### PR DESCRIPTION
Additional information added to NS002 diagnostic. In case Received-like methods are used as an extension the diagnostic looks as follows
````
Unused received check. To fix, make sure there is a call after "ReceivedWithAnyArgs". Correct: "sub.ReceivedWithAnyArgs().SomeCall();". Incorrect: "sub.ReceivedWithAnyArgs();"
````
in case of ordinal method calls the message looks as follows
````
Unused received check. To fix, make sure there is a call after "ReceivedWithAnyArgs". Correct: "SubstituteExtensions.ReceivedWithAnyArgs(sub).SomeCall();". Incorrect: "SubstituteExtensions.ReceivedWithAnyArgs(sub);"
````
Of course ``ReceivedWithAnyArgs`` is replaced with proper member name.