### PR TITLE
[GH-56] - getting semantic model only if syntax tree is within compilation

### DIFF
--- a/src/NSubstitute.Analyzers.CSharp/DiagnosticAnalyzers/ReEntrantCallFinder.cs
+++ b/src/NSubstitute.Analyzers.CSharp/DiagnosticAnalyzers/ReEntrantCallFinder.cs
@@ -34,11 +34,14 @@ namespace NSubstitute.Analyzers.CSharp.DiagnosticAnalyzers
 
             public override void VisitInvocationExpression(InvocationExpressionSyntax node)
             {
-                var semanticModel = _compilation.GetSemanticModel(node.SyntaxTree);
-                var symbolInfo = semanticModel.GetSymbolInfo(node);
-                if (_reEntrantCallFinder.IsReturnsLikeMethod(semanticModel, symbolInfo.Symbol))
+                if (_compilation.ContainsSyntaxTree(node.SyntaxTree))
                 {
-                    _invocationSymbols.Add(symbolInfo.Symbol);
+                    var semanticModel = _compilation.GetSemanticModel(node.SyntaxTree);
+                    var symbolInfo = semanticModel.GetSymbolInfo(node);
+                    if (_reEntrantCallFinder.IsReturnsLikeMethod(semanticModel, symbolInfo.Symbol))
+                    {
+                        _invocationSymbols.Add(symbolInfo.Symbol);
+                    }
                 }
 
                 base.VisitInvocationExpression(node);

--- a/src/NSubstitute.Analyzers.VisualBasic/DiagnosticAnalyzers/ReEntrantCallFinder.cs
+++ b/src/NSubstitute.Analyzers.VisualBasic/DiagnosticAnalyzers/ReEntrantCallFinder.cs
@@ -33,11 +33,14 @@ namespace NSubstitute.Analyzers.VisualBasic.DiagnosticAnalyzers
 
             public override void VisitInvocationExpression(InvocationExpressionSyntax node)
             {
-                var semanticModel = _compilation.GetSemanticModel(node.SyntaxTree);
-                var symbolInfo = semanticModel.GetSymbolInfo(node);
-                if (_reEntrantCallFinder.IsReturnsLikeMethod(semanticModel, symbolInfo.Symbol))
+                if (_compilation.ContainsSyntaxTree(node.SyntaxTree))
                 {
-                    _invocationSymbols.Add(symbolInfo.Symbol);
+                    var semanticModel = _compilation.GetSemanticModel(node.SyntaxTree);
+                    var symbolInfo = semanticModel.GetSymbolInfo(node);
+                    if (_reEntrantCallFinder.IsReturnsLikeMethod(semanticModel, symbolInfo.Symbol))
+                    {
+                        _invocationSymbols.Add(symbolInfo.Symbol);
+                    }
                 }
 
                 base.VisitInvocationExpression(node);


### PR DESCRIPTION
Closes #56 
@dtchepak this is a fix based on a stack trace only. I cannot reproduce it locally or with integration tests. @meziantou who opened the issue is not able to provide a repro as [well](https://github.com/nsubstitute/NSubstitute.Analyzers/issues/56#issuecomment-445914458) (the project where he spotted the issue is private and cannot be shared) 