### PR TITLE
Update config doc to show configuration is optional

### DIFF
--- a/documentation/Configuration.md
+++ b/documentation/Configuration.md
@@ -1,6 +1,6 @@
 ﻿# Configuring NSubstitute Analyzers
 
-NSubstitute Analyzers is configured using two separate mechanisms: code analysis rule set files, and `nsubstitute.json`.
+NSubstitute Analyzers normally does not require additional configuration. It is sufficient to reference the package in your test project. If you would like to customise how the NSubstitute Analyzers rules are applied to your project you can use one of the following configuration mechanisms:
 
 1. Code analysis rule set files
 
@@ -10,6 +10,8 @@ NSubstitute Analyzers is configured using two separate mechanisms: code analysis
 2. `nsubstitute.json`
 
    * Configure suppressions of certain rules for selected members in order to allow NSubstitute API misuse
+
+## Code analysis rule set files
 
 Code analysis rule sets are the standard way to configure most diagnostic analyzers within Visual Studio. Information about creating and customizing these files can be found in the [Using Rule Sets to Group Code Analysis Rules](https://docs.microsoft.com/visualstudio/code-quality/using-rule-sets-to-group-code-analysis-rules) documentation on docs.microsoft.com.
 


### PR DESCRIPTION
Based on StackOverflow comment [1], documentation may imply that
configuration is required. Have edited this to stress that it is optional.

Also added a separate section for Code analysis rule set files instructions
so that it stands out in the same way as the nsubstitute.json option
(otherwise is easy to skim the docs and not find how to set up the rule
set files).

[1]: https://stackoverflow.com/questions/54196778/nsubstitute-receivedcallsexception-error-when-run-calls-in-a-sequence?noredirect=1#comment95318298_54196778