### PR TITLE
[GH-142] - adding simplified InternalsVisibleTo("DynamicProxyGenAssembly2") when System.Runtime.CompilerServices in scope

### DIFF
--- a/src/NSubstitute.Analyzers.Shared/Extensions/ObjectExtensions.cs
+++ b/src/NSubstitute.Analyzers.Shared/Extensions/ObjectExtensions.cs
@@ -1,0 +1,16 @@
+namespace NSubstitute.Analyzers.Shared.Extensions
+{
+    internal static class ObjectExtensions
+    {
+        /// <summary>
+        /// Performs unsafe cast from <see cref="source"/> to <see cref="T"/>
+        /// </summary>
+        /// <param name="source">Source object.</param>
+        /// <typeparam name="T">Type to cast to.</typeparam>
+        /// <returns>Cast source.</returns>
+        public static T Cast<T>(this object source)
+        {
+            return (T)source;
+        }
+    }
+}

--- a/src/NSubstitute.Analyzers.Shared/Extensions/SyntaxGeneratorExtensions.cs
+++ b/src/NSubstitute.Analyzers.Shared/Extensions/SyntaxGeneratorExtensions.cs
@@ -3,7 +3,7 @@ using Microsoft.CodeAnalysis.Editing;
 
 namespace NSubstitute.Analyzers.Shared.Extensions
 {
-    internal static class SyntaxGeneratorExtension
+    internal static class SyntaxGeneratorExtensions
     {
         public static SyntaxNode SubstituteForInvocationExpression(
             this SyntaxGenerator syntaxGenerator,
@@ -20,6 +20,16 @@ namespace NSubstitute.Analyzers.Shared.Extensions
             var invocationExpression = syntaxGenerator.InvocationExpression(memberAccessExpression);
 
             return invocationExpression;
+        }
+
+        public static SyntaxNode InternalVisibleToDynamicProxyAttributeList(this SyntaxGenerator syntaxGenerator)
+        {
+            var attributeArguments =
+                syntaxGenerator.AttributeArgument(syntaxGenerator.LiteralExpression("DynamicProxyGenAssembly2"));
+
+            return syntaxGenerator.Attribute(
+                "System.Runtime.CompilerServices.InternalsVisibleTo",
+                attributeArguments);
         }
     }
 }

--- a/tests/NSubstitute.Analyzers.Tests.CSharp/CodeFixProviderTests/InternalSetupSpecificationCodeFixProviderTests/InternalSetupSpecificationCodeFixProviderVerifier.cs
+++ b/tests/NSubstitute.Analyzers.Tests.CSharp/CodeFixProviderTests/InternalSetupSpecificationCodeFixProviderTests/InternalSetupSpecificationCodeFixProviderVerifier.cs
@@ -44,5 +44,9 @@ namespace NSubstitute.Analyzers.Tests.CSharp.CodeFixProviderTests.InternalSetupS
         [InlineData(".FooBar()")]
         [InlineData("[0]")]
         public abstract Task AppendsInternalsVisibleTo_ToTopLevelCompilationUnit_WhenUsedWithInternalMember(string method, string call);
+
+        [CombinatoryTheory]
+        [InlineData]
+        public abstract Task AppendsInternalsVisibleToWithFullyQualifiedName_WhenUsedWithInternalMemberAndCompilerServicesNotImported(string method);
     }
 }

--- a/tests/NSubstitute.Analyzers.Tests.CSharp/CodeFixProviderTests/InternalSetupSpecificationCodeFixProviderTests/ReceivedAsExtensionMethodTests.cs
+++ b/tests/NSubstitute.Analyzers.Tests.CSharp/CodeFixProviderTests/InternalSetupSpecificationCodeFixProviderTests/ReceivedAsExtensionMethodTests.cs
@@ -350,7 +350,7 @@ namespace MyNamespace
             var newSource = $@"using NSubstitute;
 using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo(""OtherAssembly"")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""DynamicProxyGenAssembly2"")]
+[assembly: InternalsVisibleTo(""DynamicProxyGenAssembly2"")]
 
 namespace MyNamespace
 {{
@@ -375,6 +375,57 @@ namespace MyNamespace
         {{
             var substitute = NSubstitute.Substitute.For<Foo>();
             var x = substitute.{method}(){call};
+        }}
+    }}
+}}";
+            await VerifyFix(oldSource, newSource, 2);
+        }
+
+        public override async Task AppendsInternalsVisibleToWithFullyQualifiedName_WhenUsedWithInternalMemberAndCompilerServicesNotImported(string method)
+        {
+            var oldSource = $@"using NSubstitute;
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""OtherAssembly"")]
+
+namespace MyNamespace
+{{
+    public class Foo
+    {{
+        internal virtual int FooBar()
+        {{
+            return 1;
+        }}
+    }}
+
+    public class FooTests
+    {{
+        public void Test()
+        {{
+            var substitute = NSubstitute.Substitute.For<Foo>();
+            var x = substitute.{method}().FooBar();
+        }}
+    }}
+}}";
+
+            var newSource = $@"using NSubstitute;
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""OtherAssembly"")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""DynamicProxyGenAssembly2"")]
+
+namespace MyNamespace
+{{
+    public class Foo
+    {{
+        internal virtual int FooBar()
+        {{
+            return 1;
+        }}
+    }}
+
+    public class FooTests
+    {{
+        public void Test()
+        {{
+            var substitute = NSubstitute.Substitute.For<Foo>();
+            var x = substitute.{method}().FooBar();
         }}
     }}
 }}";

--- a/tests/NSubstitute.Analyzers.Tests.CSharp/CodeFixProviderTests/InternalSetupSpecificationCodeFixProviderTests/ReceivedAsOrdinaryMethodTests.cs
+++ b/tests/NSubstitute.Analyzers.Tests.CSharp/CodeFixProviderTests/InternalSetupSpecificationCodeFixProviderTests/ReceivedAsOrdinaryMethodTests.cs
@@ -350,7 +350,7 @@ namespace MyNamespace
             var newSource = $@"using NSubstitute;
 using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo(""OtherAssembly"")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""DynamicProxyGenAssembly2"")]
+[assembly: InternalsVisibleTo(""DynamicProxyGenAssembly2"")]
 
 namespace MyNamespace
 {{
@@ -375,6 +375,57 @@ namespace MyNamespace
         {{
             var substitute = NSubstitute.Substitute.For<Foo>();
             var x = {method}(substitute){call};
+        }}
+    }}
+}}";
+            await VerifyFix(oldSource, newSource, 2);
+        }
+
+        public override async Task AppendsInternalsVisibleToWithFullyQualifiedName_WhenUsedWithInternalMemberAndCompilerServicesNotImported(string method)
+        {
+            var oldSource = $@"using NSubstitute;
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""OtherAssembly"")]
+
+namespace MyNamespace
+{{
+    public class Foo
+    {{
+        internal virtual int FooBar()
+        {{
+            return 1;
+        }}
+    }}
+
+    public class FooTests
+    {{
+        public void Test()
+        {{
+            var substitute = NSubstitute.Substitute.For<Foo>();
+            var x = {method}(substitute).FooBar();
+        }}
+    }}
+}}";
+
+            var newSource = $@"using NSubstitute;
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""OtherAssembly"")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""DynamicProxyGenAssembly2"")]
+
+namespace MyNamespace
+{{
+    public class Foo
+    {{
+        internal virtual int FooBar()
+        {{
+            return 1;
+        }}
+    }}
+
+    public class FooTests
+    {{
+        public void Test()
+        {{
+            var substitute = NSubstitute.Substitute.For<Foo>();
+            var x = {method}(substitute).FooBar();
         }}
     }}
 }}";

--- a/tests/NSubstitute.Analyzers.Tests.CSharp/CodeFixProviderTests/InternalSetupSpecificationCodeFixProviderTests/ReturnsAsExtensionMethodTests.cs
+++ b/tests/NSubstitute.Analyzers.Tests.CSharp/CodeFixProviderTests/InternalSetupSpecificationCodeFixProviderTests/ReturnsAsExtensionMethodTests.cs
@@ -347,7 +347,7 @@ namespace MyNamespace
             var newSource = $@"using NSubstitute;
 using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo(""OtherAssembly"")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""DynamicProxyGenAssembly2"")]
+[assembly: InternalsVisibleTo(""DynamicProxyGenAssembly2"")]
 
 namespace MyNamespace
 {{
@@ -372,6 +372,57 @@ namespace MyNamespace
         {{
             var substitute = NSubstitute.Substitute.For<Foo>();
             var x = substitute{call}.{method}(1);
+        }}
+    }}
+}}";
+            await VerifyFix(oldSource, newSource, 2);
+        }
+
+        public override async Task AppendsInternalsVisibleToWithFullyQualifiedName_WhenUsedWithInternalMemberAndCompilerServicesNotImported(string method)
+        {
+            var oldSource = $@"using NSubstitute;
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""OtherAssembly"")]
+
+namespace MyNamespace
+{{
+    public class Foo
+    {{
+        internal virtual int FooBar()
+        {{
+            return 1;
+        }}
+    }}
+
+    public class FooTests
+    {{
+        public void Test()
+        {{
+            var substitute = NSubstitute.Substitute.For<Foo>();
+            var x = substitute.FooBar().{method}(1);
+        }}
+    }}
+}}";
+
+            var newSource = $@"using NSubstitute;
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""OtherAssembly"")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""DynamicProxyGenAssembly2"")]
+
+namespace MyNamespace
+{{
+    public class Foo
+    {{
+        internal virtual int FooBar()
+        {{
+            return 1;
+        }}
+    }}
+
+    public class FooTests
+    {{
+        public void Test()
+        {{
+            var substitute = NSubstitute.Substitute.For<Foo>();
+            var x = substitute.FooBar().{method}(1);
         }}
     }}
 }}";

--- a/tests/NSubstitute.Analyzers.Tests.CSharp/CodeFixProviderTests/InternalSetupSpecificationCodeFixProviderTests/ReturnsAsOrdinaryMethodTests.cs
+++ b/tests/NSubstitute.Analyzers.Tests.CSharp/CodeFixProviderTests/InternalSetupSpecificationCodeFixProviderTests/ReturnsAsOrdinaryMethodTests.cs
@@ -347,7 +347,7 @@ namespace MyNamespace
             var newSource = $@"using NSubstitute;
 using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo(""OtherAssembly"")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""DynamicProxyGenAssembly2"")]
+[assembly: InternalsVisibleTo(""DynamicProxyGenAssembly2"")]
 
 namespace MyNamespace
 {{
@@ -372,6 +372,57 @@ namespace MyNamespace
         {{
             var substitute = NSubstitute.Substitute.For<Foo>();
             var x = {method}(substitute{call}, 1);
+        }}
+    }}
+}}";
+            await VerifyFix(oldSource, newSource, 2);
+        }
+
+        public override async Task AppendsInternalsVisibleToWithFullyQualifiedName_WhenUsedWithInternalMemberAndCompilerServicesNotImported(string method)
+        {
+            var oldSource = $@"using NSubstitute;
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""OtherAssembly"")]
+
+namespace MyNamespace
+{{
+    public class Foo
+    {{
+        internal virtual int FooBar()
+        {{
+            return 1;
+        }}
+    }}
+
+    public class FooTests
+    {{
+        public void Test()
+        {{
+            var substitute = NSubstitute.Substitute.For<Foo>();
+            var x = {method}(substitute.FooBar(), 1);
+        }}
+    }}
+}}";
+
+            var newSource = $@"using NSubstitute;
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""OtherAssembly"")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""DynamicProxyGenAssembly2"")]
+
+namespace MyNamespace
+{{
+    public class Foo
+    {{
+        internal virtual int FooBar()
+        {{
+            return 1;
+        }}
+    }}
+
+    public class FooTests
+    {{
+        public void Test()
+        {{
+            var substitute = NSubstitute.Substitute.For<Foo>();
+            var x = {method}(substitute.FooBar(), 1);
         }}
     }}
 }}";

--- a/tests/NSubstitute.Analyzers.Tests.CSharp/CodeFixProviderTests/InternalSetupSpecificationCodeFixProviderTests/WhenAsExtensionMethodTests.cs
+++ b/tests/NSubstitute.Analyzers.Tests.CSharp/CodeFixProviderTests/InternalSetupSpecificationCodeFixProviderTests/WhenAsExtensionMethodTests.cs
@@ -350,7 +350,7 @@ namespace MyNamespace
             var newSource = $@"using NSubstitute;
 using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo(""OtherAssembly"")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""DynamicProxyGenAssembly2"")]
+[assembly: InternalsVisibleTo(""DynamicProxyGenAssembly2"")]
 
 namespace MyNamespace
 {{
@@ -375,6 +375,57 @@ namespace MyNamespace
         {{
             var substitute = NSubstitute.Substitute.For<Foo>();
             substitute.{method}(callInfo => {{var x = callInfo{call};}});
+        }}
+    }}
+}}";
+            await VerifyFix(oldSource, newSource, 2);
+        }
+
+        public override async Task AppendsInternalsVisibleToWithFullyQualifiedName_WhenUsedWithInternalMemberAndCompilerServicesNotImported(string method)
+        {
+            var oldSource = $@"using NSubstitute;
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""OtherAssembly"")]
+
+namespace MyNamespace
+{{
+    public class Foo
+    {{
+        internal virtual int FooBar()
+        {{
+            return 1;
+        }}
+    }}
+
+    public class FooTests
+    {{
+        public void Test()
+        {{
+            var substitute = NSubstitute.Substitute.For<Foo>();
+            substitute.{method}(callInfo => {{var x = callInfo.FooBar();}});
+        }}
+    }}
+}}";
+
+            var newSource = $@"using NSubstitute;
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""OtherAssembly"")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""DynamicProxyGenAssembly2"")]
+
+namespace MyNamespace
+{{
+    public class Foo
+    {{
+        internal virtual int FooBar()
+        {{
+            return 1;
+        }}
+    }}
+
+    public class FooTests
+    {{
+        public void Test()
+        {{
+            var substitute = NSubstitute.Substitute.For<Foo>();
+            substitute.{method}(callInfo => {{var x = callInfo.FooBar();}});
         }}
     }}
 }}";

--- a/tests/NSubstitute.Analyzers.Tests.CSharp/CodeFixProviderTests/InternalSetupSpecificationCodeFixProviderTests/WhenAsOrdinaryMethodTests.cs
+++ b/tests/NSubstitute.Analyzers.Tests.CSharp/CodeFixProviderTests/InternalSetupSpecificationCodeFixProviderTests/WhenAsOrdinaryMethodTests.cs
@@ -350,7 +350,7 @@ namespace MyNamespace
             var newSource = $@"using NSubstitute;
 using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo(""OtherAssembly"")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""DynamicProxyGenAssembly2"")]
+[assembly: InternalsVisibleTo(""DynamicProxyGenAssembly2"")]
 
 namespace MyNamespace
 {{
@@ -375,6 +375,57 @@ namespace MyNamespace
         {{
             var substitute = NSubstitute.Substitute.For<Foo>();
             {method}(substitute, callInfo => {{var x = callInfo{call};}});
+        }}
+    }}
+}}";
+            await VerifyFix(oldSource, newSource, 2);
+        }
+
+        public override async Task AppendsInternalsVisibleToWithFullyQualifiedName_WhenUsedWithInternalMemberAndCompilerServicesNotImported(string method)
+        {
+            var oldSource = $@"using NSubstitute;
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""OtherAssembly"")]
+
+namespace MyNamespace
+{{
+    public class Foo
+    {{
+        internal virtual int FooBar()
+        {{
+            return 1;
+        }}
+    }}
+
+    public class FooTests
+    {{
+        public void Test()
+        {{
+            var substitute = NSubstitute.Substitute.For<Foo>();
+            {method}(substitute, callInfo => {{var x = callInfo.FooBar();}});
+        }}
+    }}
+}}";
+
+            var newSource = $@"using NSubstitute;
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""OtherAssembly"")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""DynamicProxyGenAssembly2"")]
+
+namespace MyNamespace
+{{
+    public class Foo
+    {{
+        internal virtual int FooBar()
+        {{
+            return 1;
+        }}
+    }}
+
+    public class FooTests
+    {{
+        public void Test()
+        {{
+            var substitute = NSubstitute.Substitute.For<Foo>();
+            {method}(substitute, callInfo => {{var x = callInfo.FooBar();}});
         }}
     }}
 }}";

--- a/tests/NSubstitute.Analyzers.Tests.Shared/CodeFixProviders/IInternalSetupSpecificationCodeFixProviderVerifier.cs
+++ b/tests/NSubstitute.Analyzers.Tests.Shared/CodeFixProviders/IInternalSetupSpecificationCodeFixProviderVerifier.cs
@@ -17,5 +17,7 @@ namespace NSubstitute.Analyzers.Tests.Shared.CodeFixProviders
         Task AppendsProtectedInternal_ToMethod_WhenUsedWithInternalMember(string method);
 
         Task AppendsInternalsVisibleTo_ToTopLevelCompilationUnit_WhenUsedWithInternalMember(string method, string call);
+
+        Task AppendsInternalsVisibleToWithFullyQualifiedName_WhenUsedWithInternalMemberAndCompilerServicesNotImported(string method);
     }
 }

--- a/tests/NSubstitute.Analyzers.Tests.VisualBasic/CodeFixProvidersTests/InternalSetupSpecificationCodeFixProviderTests/InternalSetupSpecificationCodeFixProviderVerifier.cs
+++ b/tests/NSubstitute.Analyzers.Tests.VisualBasic/CodeFixProvidersTests/InternalSetupSpecificationCodeFixProviderTests/InternalSetupSpecificationCodeFixProviderVerifier.cs
@@ -44,5 +44,9 @@ namespace NSubstitute.Analyzers.Tests.VisualBasic.CodeFixProvidersTests.Internal
         [InlineData(".FooBar()")]
         [InlineData("(0)")]
         public abstract Task AppendsInternalsVisibleTo_ToTopLevelCompilationUnit_WhenUsedWithInternalMember(string method, string call);
+
+        [CombinatoryTheory]
+        [InlineData]
+        public abstract Task AppendsInternalsVisibleToWithFullyQualifiedName_WhenUsedWithInternalMemberAndCompilerServicesNotImported(string method);
     }
 }

--- a/tests/NSubstitute.Analyzers.Tests.VisualBasic/CodeFixProvidersTests/InternalSetupSpecificationCodeFixProviderTests/ReceivedAsExtensionMethodTests.cs
+++ b/tests/NSubstitute.Analyzers.Tests.VisualBasic/CodeFixProvidersTests/InternalSetupSpecificationCodeFixProviderTests/ReceivedAsExtensionMethodTests.cs
@@ -311,7 +311,7 @@ End Namespace
 Imports System.Runtime.CompilerServices
 
 <Assembly: InternalsVisibleTo(""OtherAssembly"")>
-<Assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""DynamicProxyGenAssembly2"")>
+<Assembly: InternalsVisibleTo(""DynamicProxyGenAssembly2"")>
 Namespace MyNamespace
     Public Class Foo
         Friend Overridable ReadOnly Property Bar As Integer
@@ -331,6 +331,49 @@ Namespace MyNamespace
         Public Sub Test()
             Dim substitute = NSubstitute.Substitute.[For](Of Foo)()
             Dim x = substitute.{method}(){call}
+        End Sub
+    End Class
+End Namespace
+";
+            await VerifyFix(oldSource, newSource, 2);
+        }
+
+        public override async Task AppendsInternalsVisibleToWithFullyQualifiedName_WhenUsedWithInternalMemberAndCompilerServicesNotImported(string method)
+        {
+            var oldSource = $@"Imports NSubstitute
+
+<Assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""OtherAssembly"")>
+Namespace MyNamespace
+    Public Class Foo
+        Friend Overridable Function FooBar() As Integer
+            Return 1
+        End Function
+    End Class
+
+    Public Class FooTests
+        Public Sub Test()
+            Dim substitute = NSubstitute.Substitute.[For](Of Foo)()
+            Dim x = substitute.{method}().FooBar()
+        End Sub
+    End Class
+End Namespace
+";
+
+            var newSource = $@"Imports NSubstitute
+
+<Assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""OtherAssembly"")>
+<Assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""DynamicProxyGenAssembly2"")>
+Namespace MyNamespace
+    Public Class Foo
+        Friend Overridable Function FooBar() As Integer
+            Return 1
+        End Function
+    End Class
+
+    Public Class FooTests
+        Public Sub Test()
+            Dim substitute = NSubstitute.Substitute.[For](Of Foo)()
+            Dim x = substitute.{method}().FooBar()
         End Sub
     End Class
 End Namespace

--- a/tests/NSubstitute.Analyzers.Tests.VisualBasic/CodeFixProvidersTests/InternalSetupSpecificationCodeFixProviderTests/ReceivedAsOrdinaryMethodTests.cs
+++ b/tests/NSubstitute.Analyzers.Tests.VisualBasic/CodeFixProvidersTests/InternalSetupSpecificationCodeFixProviderTests/ReceivedAsOrdinaryMethodTests.cs
@@ -277,7 +277,8 @@ End Namespace
             await VerifyFix(oldSource, newSource, 0);
         }
 
-        public override async Task AppendsInternalsVisibleTo_ToTopLevelCompilationUnit_WhenUsedWithInternalMember(string method, string call)
+        public override async Task AppendsInternalsVisibleTo_ToTopLevelCompilationUnit_WhenUsedWithInternalMember(
+            string method, string call)
         {
             var oldSource = $@"Imports NSubstitute
 Imports System.Runtime.CompilerServices
@@ -311,7 +312,7 @@ End Namespace
 Imports System.Runtime.CompilerServices
 
 <Assembly: InternalsVisibleTo(""OtherAssembly"")>
-<Assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""DynamicProxyGenAssembly2"")>
+<Assembly: InternalsVisibleTo(""DynamicProxyGenAssembly2"")>
 Namespace MyNamespace
     Public Class Foo
         Friend Overridable ReadOnly Property Bar As Integer
@@ -331,6 +332,49 @@ Namespace MyNamespace
         Public Sub Test()
             Dim substitute = NSubstitute.Substitute.[For](Of Foo)()
             Dim x = {method}(substitute){call}
+        End Sub
+    End Class
+End Namespace
+";
+            await VerifyFix(oldSource, newSource, 2);
+        }
+
+        public override async Task AppendsInternalsVisibleToWithFullyQualifiedName_WhenUsedWithInternalMemberAndCompilerServicesNotImported(string method)
+        {
+            var oldSource = $@"Imports NSubstitute
+
+<Assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""OtherAssembly"")>
+Namespace MyNamespace
+    Public Class Foo
+        Friend Overridable Function FooBar() As Integer
+            Return 1
+        End Function
+    End Class
+
+    Public Class FooTests
+        Public Sub Test()
+            Dim substitute = NSubstitute.Substitute.[For](Of Foo)()
+            Dim x = {method}(substitute).FooBar()
+        End Sub
+    End Class
+End Namespace
+";
+
+            var newSource = $@"Imports NSubstitute
+
+<Assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""OtherAssembly"")>
+<Assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""DynamicProxyGenAssembly2"")>
+Namespace MyNamespace
+    Public Class Foo
+        Friend Overridable Function FooBar() As Integer
+            Return 1
+        End Function
+    End Class
+
+    Public Class FooTests
+        Public Sub Test()
+            Dim substitute = NSubstitute.Substitute.[For](Of Foo)()
+            Dim x = {method}(substitute).FooBar()
         End Sub
     End Class
 End Namespace

--- a/tests/NSubstitute.Analyzers.Tests.VisualBasic/CodeFixProvidersTests/InternalSetupSpecificationCodeFixProviderTests/ReturnsAsExtensionMethodTests.cs
+++ b/tests/NSubstitute.Analyzers.Tests.VisualBasic/CodeFixProvidersTests/InternalSetupSpecificationCodeFixProviderTests/ReturnsAsExtensionMethodTests.cs
@@ -307,7 +307,7 @@ End Namespace
 Imports System.Runtime.CompilerServices
 
 <Assembly: InternalsVisibleTo(""OtherAssembly"")>
-<Assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""DynamicProxyGenAssembly2"")>
+<Assembly: InternalsVisibleTo(""DynamicProxyGenAssembly2"")>
 Namespace MyNamespace
     Public Class Foo
         Friend Overridable ReadOnly Property Bar As Integer
@@ -327,6 +327,49 @@ Namespace MyNamespace
         Public Sub Test()
             Dim substitute = NSubstitute.Substitute.[For](Of Foo)()
             Dim x = substitute{call}.{method}(1)
+        End Sub
+    End Class
+End Namespace
+";
+            await VerifyFix(oldSource, newSource, 2);
+        }
+
+        public override async Task AppendsInternalsVisibleToWithFullyQualifiedName_WhenUsedWithInternalMemberAndCompilerServicesNotImported(string method)
+        {
+            var oldSource = $@"Imports NSubstitute
+
+<Assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""OtherAssembly"")>
+Namespace MyNamespace
+    Public Class Foo
+        Friend Overridable Function FooBar() As Integer
+            Return 1
+        End Function
+    End Class
+
+    Public Class FooTests
+        Public Sub Test()
+            Dim substitute = NSubstitute.Substitute.[For](Of Foo)()
+            Dim x = substitute.FooBar().{method}(1)
+        End Sub
+    End Class
+End Namespace
+";
+
+            var newSource = $@"Imports NSubstitute
+
+<Assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""OtherAssembly"")>
+<Assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""DynamicProxyGenAssembly2"")>
+Namespace MyNamespace
+    Public Class Foo
+        Friend Overridable Function FooBar() As Integer
+            Return 1
+        End Function
+    End Class
+
+    Public Class FooTests
+        Public Sub Test()
+            Dim substitute = NSubstitute.Substitute.[For](Of Foo)()
+            Dim x = substitute.FooBar().{method}(1)
         End Sub
     End Class
 End Namespace

--- a/tests/NSubstitute.Analyzers.Tests.VisualBasic/CodeFixProvidersTests/InternalSetupSpecificationCodeFixProviderTests/ReturnsAsOrdinaryMethodTests.cs
+++ b/tests/NSubstitute.Analyzers.Tests.VisualBasic/CodeFixProvidersTests/InternalSetupSpecificationCodeFixProviderTests/ReturnsAsOrdinaryMethodTests.cs
@@ -307,7 +307,7 @@ End Namespace
 Imports System.Runtime.CompilerServices
 
 <Assembly: InternalsVisibleTo(""OtherAssembly"")>
-<Assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""DynamicProxyGenAssembly2"")>
+<Assembly: InternalsVisibleTo(""DynamicProxyGenAssembly2"")>
 Namespace MyNamespace
     Public Class Foo
         Friend Overridable ReadOnly Property Bar As Integer
@@ -327,6 +327,49 @@ Namespace MyNamespace
         Public Sub Test()
             Dim substitute = NSubstitute.Substitute.[For](Of Foo)()
             Dim x = {method}(substitute{call}, 1)
+        End Sub
+    End Class
+End Namespace
+";
+            await VerifyFix(oldSource, newSource, 2);
+        }
+
+        public override async Task AppendsInternalsVisibleToWithFullyQualifiedName_WhenUsedWithInternalMemberAndCompilerServicesNotImported(string method)
+        {
+            var oldSource = $@"Imports NSubstitute
+
+<Assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""OtherAssembly"")>
+Namespace MyNamespace
+    Public Class Foo
+        Friend Overridable Function FooBar() As Integer
+            Return 1
+        End Function
+    End Class
+
+    Public Class FooTests
+        Public Sub Test()
+            Dim substitute = NSubstitute.Substitute.[For](Of Foo)()
+            Dim x = {method}(substitute.FooBar(), 1)
+        End Sub
+    End Class
+End Namespace
+";
+
+            var newSource = $@"Imports NSubstitute
+
+<Assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""OtherAssembly"")>
+<Assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""DynamicProxyGenAssembly2"")>
+Namespace MyNamespace
+    Public Class Foo
+        Friend Overridable Function FooBar() As Integer
+            Return 1
+        End Function
+    End Class
+
+    Public Class FooTests
+        Public Sub Test()
+            Dim substitute = NSubstitute.Substitute.[For](Of Foo)()
+            Dim x = {method}(substitute.FooBar(), 1)
         End Sub
     End Class
 End Namespace

--- a/tests/NSubstitute.Analyzers.Tests.VisualBasic/CodeFixProvidersTests/InternalSetupSpecificationCodeFixProviderTests/WhenAsExtensionMethodTests.cs
+++ b/tests/NSubstitute.Analyzers.Tests.VisualBasic/CodeFixProvidersTests/InternalSetupSpecificationCodeFixProviderTests/WhenAsExtensionMethodTests.cs
@@ -337,7 +337,7 @@ End Namespace
 Imports System.Runtime.CompilerServices
 
 <Assembly: InternalsVisibleTo(""OtherAssembly"")>
-<Assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""DynamicProxyGenAssembly2"")>
+<Assembly: InternalsVisibleTo(""DynamicProxyGenAssembly2"")>
 Namespace MyNamespace
     Public Class Foo
         Friend Overridable ReadOnly Property Bar As Integer
@@ -358,6 +358,53 @@ Namespace MyNamespace
             Dim substitute = NSubstitute.Substitute.[For](Of Foo)()
             substitute.{method}(Sub(sb As Foo)
                 Dim x = sb{call}
+            End Sub)
+        End Sub
+    End Class
+End Namespace
+";
+            await VerifyFix(oldSource, newSource, 2);
+        }
+
+        public override async Task AppendsInternalsVisibleToWithFullyQualifiedName_WhenUsedWithInternalMemberAndCompilerServicesNotImported(string method)
+        {
+            var oldSource = $@"Imports NSubstitute
+
+<Assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""OtherAssembly"")>
+Namespace MyNamespace
+    Public Class Foo
+        Friend Overridable Function FooBar() As Integer
+            Return 1
+        End Function
+    End Class
+
+    Public Class FooTests
+        Public Sub Test()
+            Dim substitute = NSubstitute.Substitute.[For](Of Foo)()
+            substitute.{method}(Sub(sb As Foo)
+                Dim x = sb.FooBar()
+            End Sub)
+        End Sub
+    End Class
+End Namespace
+";
+
+            var newSource = $@"Imports NSubstitute
+
+<Assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""OtherAssembly"")>
+<Assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""DynamicProxyGenAssembly2"")>
+Namespace MyNamespace
+    Public Class Foo
+        Friend Overridable Function FooBar() As Integer
+            Return 1
+        End Function
+    End Class
+
+    Public Class FooTests
+        Public Sub Test()
+            Dim substitute = NSubstitute.Substitute.[For](Of Foo)()
+            substitute.{method}(Sub(sb As Foo)
+                Dim x = sb.FooBar()
             End Sub)
         End Sub
     End Class

--- a/tests/NSubstitute.Analyzers.Tests.VisualBasic/CodeFixProvidersTests/InternalSetupSpecificationCodeFixProviderTests/WhenAsOrdinaryMethodTests.cs
+++ b/tests/NSubstitute.Analyzers.Tests.VisualBasic/CodeFixProvidersTests/InternalSetupSpecificationCodeFixProviderTests/WhenAsOrdinaryMethodTests.cs
@@ -337,7 +337,7 @@ End Namespace
 Imports System.Runtime.CompilerServices
 
 <Assembly: InternalsVisibleTo(""OtherAssembly"")>
-<Assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""DynamicProxyGenAssembly2"")>
+<Assembly: InternalsVisibleTo(""DynamicProxyGenAssembly2"")>
 Namespace MyNamespace
     Public Class Foo
         Friend Overridable ReadOnly Property Bar As Integer
@@ -358,6 +358,53 @@ Namespace MyNamespace
             Dim substitute = NSubstitute.Substitute.[For](Of Foo)()
             {method}(substitute, Sub(sb As Foo)
                 Dim x = sb{call}
+            End Sub)
+        End Sub
+    End Class
+End Namespace
+";
+            await VerifyFix(oldSource, newSource, 2);
+        }
+
+        public override async Task AppendsInternalsVisibleToWithFullyQualifiedName_WhenUsedWithInternalMemberAndCompilerServicesNotImported(string method)
+        {
+            var oldSource = $@"Imports NSubstitute
+
+<Assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""OtherAssembly"")>
+Namespace MyNamespace
+    Public Class Foo
+        Friend Overridable Function FooBar() As Integer
+            Return 1
+        End Function
+    End Class
+
+    Public Class FooTests
+        Public Sub Test()
+            Dim substitute = NSubstitute.Substitute.[For](Of Foo)()
+            {method}(substitute, Sub(sb As Foo)
+                Dim x = sb.FooBar()
+            End Sub)
+        End Sub
+    End Class
+End Namespace
+";
+
+            var newSource = $@"Imports NSubstitute
+
+<Assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""OtherAssembly"")>
+<Assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""DynamicProxyGenAssembly2"")>
+Namespace MyNamespace
+    Public Class Foo
+        Friend Overridable Function FooBar() As Integer
+            Return 1
+        End Function
+    End Class
+
+    Public Class FooTests
+        Public Sub Test()
+            Dim substitute = NSubstitute.Substitute.[For](Of Foo)()
+            {method}(substitute, Sub(sb As Foo)
+                Dim x = sb.FooBar()
             End Sub)
         End Sub
     End Class


### PR DESCRIPTION
Closes #142 