### PR TITLE
GH-162 - analyzing all params arguments

### DIFF
--- a/src/NSubstitute.Analyzers.Shared/DiagnosticAnalyzers/AbstractSubstituteConstructorAnalysis.cs
+++ b/src/NSubstitute.Analyzers.Shared/DiagnosticAnalyzers/AbstractSubstituteConstructorAnalysis.cs
@@ -100,15 +100,6 @@ namespace NSubstitute.Analyzers.Shared.DiagnosticAnalyzers
 
         private ITypeSymbol[] GetArgumentTypeInfo(SubstituteContext<TInvocationExpression> substituteContext, TArgumentSyntax arrayArgument)
         {
-            var typeInfo = GetTypeInfo(substituteContext, arrayArgument.DescendantNodes().First());
-
-            if (typeInfo.ConvertedType != null &&
-                typeInfo.ConvertedType.TypeKind == TypeKind.Array &&
-                typeInfo.Type == null)
-            {
-                return null;
-            }
-
             // new object[] { }; // means we dont pass any arguments
             var parameterExpressionsFromArrayArgument = GetParameterExpressionsFromArrayArgument(arrayArgument);
             if (parameterExpressionsFromArrayArgument == null)

--- a/tests/NSubstitute.Analyzers.Tests.CSharp/DiagnosticAnalyzerTests/SubstituteAnalyzerTests/ForAsGenericMethodTests.cs
+++ b/tests/NSubstitute.Analyzers.Tests.CSharp/DiagnosticAnalyzerTests/SubstituteAnalyzerTests/ForAsGenericMethodTests.cs
@@ -490,9 +490,13 @@ namespace MyNamespace
         [InlineData("int x", "1D")]
         [InlineData("List<int> x", "new List<int>().AsReadOnly()")]
         [InlineData("params int[] x", "1m")]
+        [InlineData("params int[] x", "1, 1m")]
         [InlineData("int x", "new [] { 1 }")]
         [InlineData("int x", "new object()")]
         [InlineData("params int[] x", "new [] { 1m }")]
+        [InlineData("params int[] x", "new [] { 1, 1m }")]
+        [InlineData("params int[] x", "new object[] { 1m }")]
+        [InlineData("params int[] x", "new object[] { 1, 1m }")]
         public override async Task ReportsDiagnostic_WhenConstructorArgumentsRequireExplicitConversion(string ctorValues, string invocationValues)
         {
             var source = $@"using NSubstitute;
@@ -535,7 +539,7 @@ namespace MyNamespace
         [InlineData("int x", "new object[] { null }")] // even though we pass null as first arg, this works fine with NSubstitute
         [InlineData("int x, int y", "new object[] { null, null }")] // even though we pass null as first arg, this works fine with NSubstitute
         [InlineData("int x, int y", "new object[] { 1, null }")] // even though we pass null as first arg, this works fine with NSubstitute
-        [InlineData("int x, params string[] y", "new object[] { 1, \"foo\" }")]
+        [InlineData("int x, params string[] y", "new object[] { 1, \"foo\", \"foo\"  }")]
         public override async Task ReportsNoDiagnostic_WhenConstructorArgumentsDoNotRequireImplicitConversion(string ctorValues, string invocationValues)
         {
             var source = $@"using NSubstitute;

--- a/tests/NSubstitute.Analyzers.Tests.CSharp/DiagnosticAnalyzerTests/SubstituteAnalyzerTests/ForAsNonGenericMethodTests.cs
+++ b/tests/NSubstitute.Analyzers.Tests.CSharp/DiagnosticAnalyzerTests/SubstituteAnalyzerTests/ForAsNonGenericMethodTests.cs
@@ -545,6 +545,9 @@ namespace MyNamespace
         [InlineData("List<int> x", "new List<int>().AsReadOnly()")]
         [InlineData("int x", "new [] { new object() }")]
         [InlineData("params int[] x", "new [] { 1m }")]
+        [InlineData("params int[] x", "new [] { 1, 1m }")]
+        [InlineData("params int[] x", "new object[] { 1m }")]
+        [InlineData("params int[] x", "new object[] { 1, 1m }")]
         public override async Task ReportsDiagnostic_WhenConstructorArgumentsRequireExplicitConversion(string ctorValues, string invocationValues)
         {
             var source = $@"using NSubstitute;
@@ -579,7 +582,7 @@ namespace MyNamespace
         [InlineData("IEnumerable<char> x", @"new object [] { ""value"" }")]
         [InlineData("", @"new object[] { }")]
         [InlineData("", "new object[] { 1, 2 }.ToArray()")] // actual values known at runtime only so constructor analysis skipped
-        [InlineData("int x, params string[] y", "new object[] { 1, \"foo\" }")]
+        [InlineData("int x, params string[] y", "new object[] { 1, \"foo\", \"foo\" }")]
         public override async Task ReportsNoDiagnostic_WhenConstructorArgumentsDoNotRequireImplicitConversion(string ctorValues, string invocationValues)
         {
             var source = $@"using NSubstitute;

--- a/tests/NSubstitute.Analyzers.Tests.CSharp/DiagnosticAnalyzerTests/SubstituteAnalyzerTests/ForPartsOfMethodTests.cs
+++ b/tests/NSubstitute.Analyzers.Tests.CSharp/DiagnosticAnalyzerTests/SubstituteAnalyzerTests/ForPartsOfMethodTests.cs
@@ -321,9 +321,13 @@ namespace MyNamespace
         [InlineData("int x", "1m")]
         [InlineData("int x", "1D")]
         [InlineData("params int[] x", "1m")]
+        [InlineData("params int[] x", "1, 1m")]
         [InlineData("List<int> x", "new List<int>().AsReadOnly()")]
         [InlineData("int x", "new object()")]
         [InlineData("params int[] x", "new [] { 1m }")]
+        [InlineData("params int[] x", "new [] { 1, 1m }")]
+        [InlineData("params int[] x", "new object[] { 1m }")]
+        [InlineData("params int[] x", "new object[] { 1, 1m }")]
         public override async Task ReportsDiagnostic_WhenConstructorArgumentsRequireExplicitConversion(string ctorValues, string invocationValues)
         {
             var source = $@"using NSubstitute;
@@ -356,14 +360,14 @@ namespace MyNamespace
         [InlineData("IEnumerable<int> x", "new List<int>()")]
         [InlineData("IEnumerable<int> x", "new List<int>().AsReadOnly()")]
         [InlineData("IEnumerable<char> x", @"""value""")]
-        [InlineData("int x, params string[] y", "1, \"foo\"")]
+        [InlineData("int x, params string[] y", "1, \"foo\", \"foo\"")]
         [InlineData("int x", @"new object[] { 1 }")]
         [InlineData("int[] x", @"new int[] { 1 }")]
         [InlineData("object[] x , int y", @"new object[] { 1 }, 1")]
         [InlineData("int[] x , int y", @"new int[] { 1 }, 1")]
         [InlineData("", @"new object[] { }")]
         [InlineData("", "new object[] { 1, 2 }.ToArray()")] // actual values known at runtime only
-        [InlineData("int x, params string[] y", "new object[] { 1, \"foo\" }")]
+        [InlineData("int x, params string[] y", "new object[] { 1, \"foo\", \"foo\" }")]
         public override async Task ReportsNoDiagnostic_WhenConstructorArgumentsDoNotRequireImplicitConversion(string ctorValues, string invocationValues)
         {
             var source = $@"using NSubstitute;

--- a/tests/NSubstitute.Analyzers.Tests.CSharp/DiagnosticAnalyzerTests/SubstituteAnalyzerTests/SubstituteFactoryCreateMethodTests.cs
+++ b/tests/NSubstitute.Analyzers.Tests.CSharp/DiagnosticAnalyzerTests/SubstituteAnalyzerTests/SubstituteFactoryCreateMethodTests.cs
@@ -511,6 +511,9 @@ namespace MyNamespace
         [InlineData("List<int> x", "new List<int>().AsReadOnly()")]
         [InlineData("int x", "new object()")]
         [InlineData("params int[] x", "new [] { 1m }")]
+        [InlineData("params int[] x", "new [] { 1, 1m }")]
+        [InlineData("params int[] x", "new object[] { 1m }")]
+        [InlineData("params int[] x", "new object[] { 1, 1m }")]
         public override async Task ReportsDiagnostic_WhenConstructorArgumentsRequireExplicitConversion(string ctorValues, string invocationValues)
         {
             var source = $@"using System.Collections.Generic;
@@ -547,7 +550,7 @@ namespace MyNamespace
         [InlineData("IEnumerable<char> x", @"new object [] { ""value"" }")]
         [InlineData("", @"new object[] { }")]
         [InlineData("", "new object[] { 1, 2 }.ToArray()")] // actual values known at runtime only so constructor analysys skipped
-        [InlineData("int x, params string[] y", "new object[] { 1, \"foo\" }")]
+        [InlineData("int x, params string[] y", "new object[] { 1, \"foo\", \"foo\" }")]
         public override async Task ReportsNoDiagnostic_WhenConstructorArgumentsDoNotRequireImplicitConversion(string ctorValues, string invocationValues)
         {
             var source = $@"using System.Collections.Generic;

--- a/tests/NSubstitute.Analyzers.Tests.CSharp/DiagnosticAnalyzerTests/SubstituteAnalyzerTests/SubstituteFactoryCreatePartialMethodTests.cs
+++ b/tests/NSubstitute.Analyzers.Tests.CSharp/DiagnosticAnalyzerTests/SubstituteAnalyzerTests/SubstituteFactoryCreatePartialMethodTests.cs
@@ -340,6 +340,9 @@ namespace MyNamespace
         [InlineData("List<int> x", "new List<int>().AsReadOnly()")]
         [InlineData("int x", "new object()")]
         [InlineData("params int[] x", "new [] { 1m }")]
+        [InlineData("params int[] x", "new [] { 1, 1m }")]
+        [InlineData("params int[] x", "new object[] { 1m }")]
+        [InlineData("params int[] x", "new object[] { 1, 1m }")]
         public override async Task ReportsDiagnostic_WhenConstructorArgumentsRequireExplicitConversion(string ctorValues, string invocationValues)
         {
             var source = $@"using System.Collections.Generic;
@@ -376,7 +379,7 @@ namespace MyNamespace
         [InlineData("IEnumerable<char> x", @"new object [] { ""value"" }")]
         [InlineData("", @"new object[] { }")]
         [InlineData("", "new object[] { 1, 2 }.ToArray()")] // actual values known at runtime only so constructor analysys skipped
-        [InlineData("int x, params string[] y", "new object[] { 1, \"foo\" }")]
+        [InlineData("int x, params string[] y", "new object[] { 1, \"foo\", \"foo\" }")]
         public override async Task ReportsNoDiagnostic_WhenConstructorArgumentsDoNotRequireImplicitConversion(string ctorValues, string invocationValues)
         {
             var source = $@"using System.Collections.Generic;

--- a/tests/NSubstitute.Analyzers.Tests.VisualBasic/DiagnosticAnalyzersTests/SubstituteAnalyzerTests/ForAsGenericMethodTests.cs
+++ b/tests/NSubstitute.Analyzers.Tests.VisualBasic/DiagnosticAnalyzersTests/SubstituteAnalyzerTests/ForAsGenericMethodTests.cs
@@ -417,9 +417,13 @@ End Namespace
         [InlineData("ByVal x As Integer", "1D")]
         [InlineData("ByVal x As Integer", "1R")]
         [InlineData("ParamArray z As Integer()", "1D")]
+        [InlineData("ParamArray z As Integer()", "1, 1D")]
         [InlineData("ByVal x As List(Of Integer)", "New List(Of Integer)().AsReadOnly()")]
         [InlineData("ByVal x As Integer", "New Object()")]
         [InlineData("ParamArray z As Integer()", "New Object() { 1D }")]
+        [InlineData("ParamArray z As Integer()", "New Object() { 1, 1D }")]
+        [InlineData("ParamArray z As Integer()", "{ 1D }")]
+        [InlineData("ParamArray z As Integer()", "{ 1, 1D }")]
         public override async Task ReportsDiagnostic_WhenConstructorArgumentsRequireExplicitConversion(string ctorValues, string invocationValues)
         {
             var source = $@"Imports NSubstitute
@@ -449,7 +453,7 @@ End Namespace
         [InlineData("ByVal x As IEnumerable(Of Integer)", "New List(Of Integer)()")]
         [InlineData("ByVal x As IEnumerable(Of Integer)", "New List(Of Integer)().AsReadOnly()")]
         [InlineData("ByVal x As IEnumerable(Of Char)", @"""value""")]
-        [InlineData("ByVal x As Integer, ParamArray z As String()", "1, \"foo\"")]
+        [InlineData("ByVal x As Integer, ParamArray z As String()", "1, \"foo\", \"foo\"")]
         [InlineData("ByVal x As Integer", @"New Object() {1}")]
         [InlineData("ByVal x As Integer()", @"New Integer() {1}")]
         [InlineData("ByVal x As Object(), ByVal y As Integer", @"New Object() {1}, 1")]
@@ -459,7 +463,7 @@ End Namespace
         [InlineData("ByVal x As Integer", "New Object() {Nothing}")] // even though we pass null as first arg, this works fine with NSubstitute
         [InlineData("ByVal x As Integer, ByVal y As Integer", "New Object() { Nothing, Nothing }")] // even though we pass null as first arg, this works fine with NSubstitute
         [InlineData("ByVal x As Integer, ByVal y As Integer", "New Object() {1, Nothing}")] // even though we pass null as last arg, this works fine with NSubstitute
-        [InlineData("ByVal x As Integer, ParamArray z As String()", "New Object() {1, \"foo\"}")]
+        [InlineData("ByVal x As Integer, ParamArray z As String()", "New Object() {1, \"foo\", \"foo\"}")]
         public override async Task ReportsNoDiagnostic_WhenConstructorArgumentsDoNotRequireImplicitConversion(string ctorValues, string invocationValues)
         {
             var source = $@"Imports NSubstitute

--- a/tests/NSubstitute.Analyzers.Tests.VisualBasic/DiagnosticAnalyzersTests/SubstituteAnalyzerTests/ForAsNonGenericMethodTests.cs
+++ b/tests/NSubstitute.Analyzers.Tests.VisualBasic/DiagnosticAnalyzersTests/SubstituteAnalyzerTests/ForAsNonGenericMethodTests.cs
@@ -466,6 +466,9 @@ End Namespace
         [InlineData("ByVal x As Integer", "New Object() { 1R }")]
         [InlineData("ByVal x As List(Of Integer)", "New Object() { New List(Of Integer)().AsReadOnly() }")]
         [InlineData("ParamArray z As Integer()", "New Object() { 1D }")]
+        [InlineData("ParamArray z As Integer()", "New Object() { 1, 1D }")]
+        [InlineData("ParamArray z As Integer()", "{ 1D }")]
+        [InlineData("ParamArray z As Integer()", "{ 1, 1D }")]
 
         // [InlineData("ByVal x As Integer", "New Object()")] This gives runtime error on VB level, not even NSubstitute level (but compiles just fine)
         public override async Task ReportsDiagnostic_WhenConstructorArgumentsRequireExplicitConversion(string ctorValues, string invocationValues)
@@ -499,7 +502,7 @@ End Namespace";
         [InlineData("ByVal x As IEnumerable(Of Char)", @"New Object() {""value""}")]
         [InlineData("", @"New Object() {}")]
         [InlineData("", "New Object() {1, 2}.ToArray()")] // actual values known at runtime only so constructor analysys skipped
-        [InlineData("ByVal x As Integer, ParamArray z As String()", "New Object() { 1, \"foo\" }")]
+        [InlineData("ByVal x As Integer, ParamArray z As String()", "New Object() { 1, \"foo\", \"foo\" }")]
         public override async Task ReportsNoDiagnostic_WhenConstructorArgumentsDoNotRequireImplicitConversion(string ctorValues, string invocationValues)
         {
             var source = $@"Imports NSubstitute

--- a/tests/NSubstitute.Analyzers.Tests.VisualBasic/DiagnosticAnalyzersTests/SubstituteAnalyzerTests/ForPartsOfMethodTests.cs
+++ b/tests/NSubstitute.Analyzers.Tests.VisualBasic/DiagnosticAnalyzersTests/SubstituteAnalyzerTests/ForPartsOfMethodTests.cs
@@ -271,9 +271,13 @@ End Namespace
         [InlineData("ByVal x As Integer", "1D")]
         [InlineData("ByVal x As Integer", "1R")]
         [InlineData("ParamArray z As Integer()", "1D")]
+        [InlineData("ParamArray z As Integer()", "1, 1D")]
         [InlineData("ByVal x As List(Of Integer)", "New List(Of Integer)().AsReadOnly()")]
         [InlineData("ByVal x As Integer", "New Object()")]
         [InlineData("ParamArray z As Integer()", "New Object() { 1D }")]
+        [InlineData("ParamArray z As Integer()", "New Object() { 1, 1D }")]
+        [InlineData("ParamArray z As Integer()", "{ 1D }")]
+        [InlineData("ParamArray z As Integer()", "{ 1, 1D }")]
         public override async Task ReportsDiagnostic_WhenConstructorArgumentsRequireExplicitConversion(string ctorValues, string invocationValues)
         {
             var source = $@"Imports NSubstitute
@@ -303,10 +307,10 @@ End Namespace
         [InlineData("ByVal x As IEnumerable(Of Integer)", "New Object() {New List(Of Integer)()}")]
         [InlineData("ByVal x As IEnumerable(Of Integer)", "New Object() {New List(Of Integer)().AsReadOnly()}")]
         [InlineData("ByVal x As IEnumerable(Of Char)", @"New Object() {""value""}")]
-        [InlineData("ByVal x As Integer, ParamArray z As String()", "1, \"foo\"")]
+        [InlineData("ByVal x As Integer, ParamArray z As String()", "1, \"foo\", \"foo\"")]
         [InlineData("", @"New Object() {}")]
         [InlineData("", "New Object() {1, 2}.ToArray()")] // actual values known at runtime only so constructor analysys skipped
-        [InlineData("ByVal x As Integer, ParamArray z As String()", "New Object() {1, \"foo\"}")]
+        [InlineData("ByVal x As Integer, ParamArray z As String()", "New Object() {1, \"foo\", \"foo\" }")]
         public override async Task ReportsNoDiagnostic_WhenConstructorArgumentsDoNotRequireImplicitConversion(string ctorValues, string invocationValues)
         {
             var source = $@"Imports NSubstitute

--- a/tests/NSubstitute.Analyzers.Tests.VisualBasic/DiagnosticAnalyzersTests/SubstituteAnalyzerTests/SubstituteFactoryCreateMethodTests.cs
+++ b/tests/NSubstitute.Analyzers.Tests.VisualBasic/DiagnosticAnalyzersTests/SubstituteAnalyzerTests/SubstituteFactoryCreateMethodTests.cs
@@ -430,6 +430,9 @@ End Namespace";
         [InlineData("ByVal x As Integer", "New Object() { 1R }")]
         [InlineData("ByVal x As List(Of Integer)", "New Object() { New List(Of Integer)().AsReadOnly() }")]
         [InlineData("ParamArray z As Integer()", "New Object() { 1D }")]
+        [InlineData("ParamArray z As Integer()", "New Object() { 1, 1D }")]
+        [InlineData("ParamArray z As Integer()", "{ 1D }")]
+        [InlineData("ParamArray z As Integer()", "{ 1, 1D }")]
 
         // [InlineData("ByVal x As Integer", "New Object()")] This gives runtime error on VB level, not even NSubstitute level (but compiles just fine)
         public override async Task ReportsDiagnostic_WhenConstructorArgumentsRequireExplicitConversion(string ctorValues, string invocationValues)
@@ -464,7 +467,7 @@ End Namespace";
         [InlineData("ByVal x As IEnumerable(Of Char)", @"New Object() {""value""}")]
         [InlineData("", @"New Object() {}")]
         [InlineData("", "New Object() {1, 2}.ToArray()")] // actual values known at runtime only so constructor analysys skipped
-        [InlineData("ByVal x As Integer, ParamArray z As String()", "New Object() { 1, \"foo\" }")]
+        [InlineData("ByVal x As Integer, ParamArray z As String()", "New Object() { 1, \"foo\", \"foo\" }")]
         public override async Task ReportsNoDiagnostic_WhenConstructorArgumentsDoNotRequireImplicitConversion(string ctorValues, string invocationValues)
         {
             var source = $@"Imports NSubstitute

--- a/tests/NSubstitute.Analyzers.Tests.VisualBasic/DiagnosticAnalyzersTests/SubstituteAnalyzerTests/SubstituteFactoryCreatePartialMethodTests.cs
+++ b/tests/NSubstitute.Analyzers.Tests.VisualBasic/DiagnosticAnalyzersTests/SubstituteAnalyzerTests/SubstituteFactoryCreatePartialMethodTests.cs
@@ -290,6 +290,9 @@ End Namespace
         [InlineData("ByVal x As Integer", "New Object() { 1R }")]
         [InlineData("ByVal x As List(Of Integer)", "New Object() { New List(Of Integer)().AsReadOnly() }")]
         [InlineData("ParamArray z As Integer()", "New Object() { 1D }")]
+        [InlineData("ParamArray z As Integer()", "New Object() { 1, 1D }")]
+        [InlineData("ParamArray z As Integer()", "{ 1D }")]
+        [InlineData("ParamArray z As Integer()", "{ 1, 1D }")]
 
         // [InlineData("ByVal x As Integer", "New Object()")] This gives runtime error on VB level, not even NSubstitute level (but compiles just fine)
         public override async Task ReportsDiagnostic_WhenConstructorArgumentsRequireExplicitConversion(string ctorValues, string invocationValues)
@@ -324,7 +327,7 @@ End Namespace";
         [InlineData("ByVal x As IEnumerable(Of Char)", @"New Object() {""value""}")]
         [InlineData("", @"New Object() {}")]
         [InlineData("", "New Object() {1, 2}.ToArray()")] // actual values known at runtime only so constructor analysys skipped
-        [InlineData("ByVal x As Integer, ParamArray z As String()", "New Object() { 1, \"foo\" }")]
+        [InlineData("ByVal x As Integer, ParamArray z As String()", "New Object() { 1, \"foo\", \"foo\" }")]
         public override async Task ReportsNoDiagnostic_WhenConstructorArgumentsDoNotRequireImplicitConversion(string ctorValues, string invocationValues)
         {
             var source = $@"Imports NSubstitute


### PR DESCRIPTION
Improvements for #162

@dtchepak initial fix for #162 was not validating all params elements, so invalid cases like this
```c#
            var substitute = NSubstitute.Substitute.For<Foo>(new object[] { 1, 1m });
```
were not detected. This PR aims to fix that problem