### PR TITLE
[GH-153] - handling out of order named parameters for first batch of analyzers

### DIFF
--- a/src/NSubstitute.Analyzers.CSharp/DiagnosticAnalyzers/NonSubstitutableMemberAnalyzer.cs
+++ b/src/NSubstitute.Analyzers.CSharp/DiagnosticAnalyzers/NonSubstitutableMemberAnalyzer.cs
@@ -1,26 +1,14 @@
-using System.Collections.Immutable;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using NSubstitute.Analyzers.Shared.DiagnosticAnalyzers;
 
 namespace NSubstitute.Analyzers.CSharp.DiagnosticAnalyzers;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
-internal sealed class NonSubstitutableMemberAnalyzer : AbstractNonSubstitutableMemberAnalyzer<SyntaxKind, InvocationExpressionSyntax>
+internal sealed class NonSubstitutableMemberAnalyzer : AbstractNonSubstitutableMemberAnalyzer<SyntaxKind>
 {
     protected override SyntaxKind InvocationExpressionKind { get; } = SyntaxKind.InvocationExpression;
-
-    protected override ImmutableHashSet<int> SupportedMemberAccesses { get; } = ImmutableHashSet.Create(
-        (int)SyntaxKind.InvocationExpression,
-        (int)SyntaxKind.SimpleMemberAccessExpression,
-        (int)SyntaxKind.ElementAccessExpression,
-        (int)SyntaxKind.NumericLiteralExpression,
-        (int)SyntaxKind.CharacterLiteralExpression,
-        (int)SyntaxKind.FalseLiteralExpression,
-        (int)SyntaxKind.TrueLiteralExpression,
-        (int)SyntaxKind.StringLiteralExpression);
 
     public NonSubstitutableMemberAnalyzer()
         : base(NSubstitute.Analyzers.CSharp.DiagnosticDescriptorsProvider.Instance, SubstitutionNodeFinder.Instance, NonSubstitutableMemberAnalysis.Instance)

--- a/src/NSubstitute.Analyzers.CSharp/DiagnosticAnalyzers/NonSubstitutableMemberReceivedAnalyzer.cs
+++ b/src/NSubstitute.Analyzers.CSharp/DiagnosticAnalyzers/NonSubstitutableMemberReceivedAnalyzer.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Immutable;
-using Microsoft.CodeAnalysis;
+﻿using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -10,11 +9,6 @@ namespace NSubstitute.Analyzers.CSharp.DiagnosticAnalyzers;
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 internal sealed class NonSubstitutableMemberReceivedAnalyzer : AbstractNonSubstitutableMemberReceivedAnalyzer<SyntaxKind, MemberAccessExpressionSyntax>
 {
-    protected override ImmutableHashSet<int> PossibleParentsRawKinds { get; } = ImmutableHashSet.Create(
-        (int)SyntaxKind.SimpleMemberAccessExpression,
-        (int)SyntaxKind.InvocationExpression,
-        (int)SyntaxKind.ElementAccessExpression);
-
     protected override SyntaxKind InvocationExpressionKind { get; } = SyntaxKind.InvocationExpression;
 
     public NonSubstitutableMemberReceivedAnalyzer()

--- a/src/NSubstitute.Analyzers.CSharp/DiagnosticAnalyzers/NonSubstitutableMemberReceivedInOrderAnalyzer.cs
+++ b/src/NSubstitute.Analyzers.CSharp/DiagnosticAnalyzers/NonSubstitutableMemberReceivedInOrderAnalyzer.cs
@@ -8,7 +8,7 @@ using NSubstitute.Analyzers.Shared.DiagnosticAnalyzers;
 namespace NSubstitute.Analyzers.CSharp.DiagnosticAnalyzers;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
-internal sealed class NonSubstitutableMemberReceivedInOrderAnalyzer : AbstractNonSubstitutableMemberReceivedInOrderAnalyzer<SyntaxKind, InvocationExpressionSyntax, MemberAccessExpressionSyntax, BlockSyntax>
+internal sealed class NonSubstitutableMemberReceivedInOrderAnalyzer : AbstractNonSubstitutableMemberReceivedInOrderAnalyzer<SyntaxKind, MemberAccessExpressionSyntax, BlockSyntax>
 {
     private static ImmutableArray<int> IgnoredPaths { get; } =
         ImmutableArray.Create((int)SyntaxKind.Argument, (int)SyntaxKind.VariableDeclarator, (int)SyntaxKind.AddAssignmentExpression);

--- a/src/NSubstitute.Analyzers.CSharp/DiagnosticAnalyzers/NonSubstitutableMemberWhenAnalyzer.cs
+++ b/src/NSubstitute.Analyzers.CSharp/DiagnosticAnalyzers/NonSubstitutableMemberWhenAnalyzer.cs
@@ -1,13 +1,12 @@
 ﻿using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using NSubstitute.Analyzers.Shared.DiagnosticAnalyzers;
 
 namespace NSubstitute.Analyzers.CSharp.DiagnosticAnalyzers;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
-internal sealed class NonSubstitutableMemberWhenAnalyzer : AbstractNonSubstitutableMemberWhenAnalyzer<SyntaxKind, InvocationExpressionSyntax>
+internal sealed class NonSubstitutableMemberWhenAnalyzer : AbstractNonSubstitutableMemberWhenAnalyzer<SyntaxKind>
 {
     public NonSubstitutableMemberWhenAnalyzer()
         : base(NSubstitute.Analyzers.CSharp.DiagnosticDescriptorsProvider.Instance, SubstitutionNodeFinder.Instance, NonSubstitutableMemberAnalysis.Instance)

--- a/src/NSubstitute.Analyzers.CSharp/DiagnosticAnalyzers/ReEntrantCallFinder.cs
+++ b/src/NSubstitute.Analyzers.CSharp/DiagnosticAnalyzers/ReEntrantCallFinder.cs
@@ -12,7 +12,7 @@ internal class ReEntrantCallFinder : AbstractReEntrantCallFinder<InvocationExpre
 {
     public static ReEntrantCallFinder Instance { get; } = new ReEntrantCallFinder(SubstitutionNodeFinder.Instance);
 
-    private ReEntrantCallFinder(ISubstitutionNodeFinder<InvocationExpressionSyntax> substitutionNodeFinder)
+    private ReEntrantCallFinder(ISubstitutionNodeFinder substitutionNodeFinder)
         : base(substitutionNodeFinder)
     {
     }

--- a/src/NSubstitute.Analyzers.CSharp/DiagnosticAnalyzers/ReceivedInReceivedInOrderAnalyzer.cs
+++ b/src/NSubstitute.Analyzers.CSharp/DiagnosticAnalyzers/ReceivedInReceivedInOrderAnalyzer.cs
@@ -1,13 +1,12 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using NSubstitute.Analyzers.Shared.DiagnosticAnalyzers;
 
 namespace NSubstitute.Analyzers.CSharp.DiagnosticAnalyzers;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
-internal sealed class ReceivedInReceivedInOrderAnalyzer : AbstractReceivedInReceivedInOrderAnalyzer<SyntaxKind, InvocationExpressionSyntax>
+internal sealed class ReceivedInReceivedInOrderAnalyzer : AbstractReceivedInReceivedInOrderAnalyzer<SyntaxKind>
 {
     public ReceivedInReceivedInOrderAnalyzer()
         : base(SubstitutionNodeFinder.Instance, CSharp.DiagnosticDescriptorsProvider.Instance)

--- a/src/NSubstitute.Analyzers.Shared/DiagnosticAnalyzers/AbstractCallInfoAnalyzer.cs
+++ b/src/NSubstitute.Analyzers.Shared/DiagnosticAnalyzers/AbstractCallInfoAnalyzer.cs
@@ -16,13 +16,13 @@ internal abstract class AbstractCallInfoAnalyzer<TSyntaxKind, TInvocationExpress
     where TSyntaxKind : struct
 {
     private readonly ICallInfoFinder<TInvocationExpressionSyntax, TIndexerExpressionSyntax> _callInfoFinder;
-    private readonly ISubstitutionNodeFinder<TInvocationExpressionSyntax> _substitutionNodeFinder;
+    private readonly ISubstitutionNodeFinder _substitutionNodeFinder;
     private readonly Action<SyntaxNodeAnalysisContext> _analyzeInvocationAction;
 
     protected AbstractCallInfoAnalyzer(
         IDiagnosticDescriptorsProvider diagnosticDescriptorsProvider,
         ICallInfoFinder<TInvocationExpressionSyntax, TIndexerExpressionSyntax> callInfoFinder,
-        ISubstitutionNodeFinder<TInvocationExpressionSyntax> substitutionNodeFinder)
+        ISubstitutionNodeFinder substitutionNodeFinder)
         : base(diagnosticDescriptorsProvider)
     {
         _callInfoFinder = callInfoFinder;

--- a/src/NSubstitute.Analyzers.Shared/DiagnosticAnalyzers/AbstractSyncOverAsyncThrowsAnalyzer.cs
+++ b/src/NSubstitute.Analyzers.Shared/DiagnosticAnalyzers/AbstractSyncOverAsyncThrowsAnalyzer.cs
@@ -11,14 +11,14 @@ internal abstract class AbstractSyncOverAsyncThrowsAnalyzer<TSyntaxKind, TInvoca
     where TInvocationExpressionSyntax : SyntaxNode
     where TSyntaxKind : struct
 {
-    private readonly ISubstitutionNodeFinder<TInvocationExpressionSyntax> _substitutionNodeFinder;
+    private readonly ISubstitutionNodeFinder _substitutionNodeFinder;
     private readonly Action<SyntaxNodeAnalysisContext> _analyzeInvocationAction;
 
     protected abstract TSyntaxKind InvocationExpressionKind { get; }
 
     protected AbstractSyncOverAsyncThrowsAnalyzer(
         IDiagnosticDescriptorsProvider diagnosticDescriptorsProvider,
-        ISubstitutionNodeFinder<TInvocationExpressionSyntax> substitutionNodeFinder)
+        ISubstitutionNodeFinder substitutionNodeFinder)
         : base(diagnosticDescriptorsProvider)
     {
         _substitutionNodeFinder = substitutionNodeFinder;

--- a/src/NSubstitute.Analyzers.Shared/DiagnosticAnalyzers/ISubstitutionNodeFinder.cs
+++ b/src/NSubstitute.Analyzers.Shared/DiagnosticAnalyzers/ISubstitutionNodeFinder.cs
@@ -5,17 +5,17 @@ using Microsoft.CodeAnalysis.Operations;
 
 namespace NSubstitute.Analyzers.Shared.DiagnosticAnalyzers;
 
-internal interface ISubstitutionNodeFinder<in TInvocationExpressionSyntax> where TInvocationExpressionSyntax : SyntaxNode
+internal interface ISubstitutionNodeFinder
 {
-    IEnumerable<SyntaxNode> Find(SyntaxNodeAnalysisContext syntaxNodeContext, TInvocationExpressionSyntax invocationExpression, IMethodSymbol invocationExpressionSymbol = null);
+    IEnumerable<SyntaxNode> Find(SyntaxNodeAnalysisContext syntaxNodeContext, SyntaxNode invocationExpression, IMethodSymbol invocationExpressionSymbol);
 
-    IEnumerable<SyntaxNode> FindForWhenExpression(SyntaxNodeAnalysisContext syntaxNodeContext, TInvocationExpressionSyntax whenInvocationExpression, IMethodSymbol whenInvocationSymbol = null);
+    IEnumerable<SyntaxNode> Find(SyntaxNodeAnalysisContext syntaxNodeContext, IInvocationOperation invocationOperation, IMethodSymbol invocationExpressionSymbol = null);
 
-    IEnumerable<SyntaxNode> FindForReceivedInOrderExpression(SyntaxNodeAnalysisContext syntaxNodeContext, TInvocationExpressionSyntax receivedInOrderExpression, IMethodSymbol receivedInOrderInvocationSymbol = null);
+    IEnumerable<SyntaxNode> FindForWhenExpression(SyntaxNodeAnalysisContext syntaxNodeContext, IInvocationOperation invocationOperation, IMethodSymbol whenInvocationSymbol = null);
 
-    SyntaxNode FindForAndDoesExpression(SyntaxNodeAnalysisContext syntaxNodeContext, TInvocationExpressionSyntax invocationExpression, IMethodSymbol invocationExpressionSymbol = null);
-
-    SyntaxNode FindForStandardExpression(TInvocationExpressionSyntax invocationExpressionSyntax, IMethodSymbol invocationExpressionSymbol = null);
+    IEnumerable<SyntaxNode> FindForReceivedInOrderExpression(SyntaxNodeAnalysisContext syntaxNodeContext, IInvocationOperation invocationOperation, IMethodSymbol receivedInOrderInvocationSymbol = null);
 
     SyntaxNode FindForStandardExpression(IInvocationOperation invocationOperation);
+
+    IOperation FindOperationForStandardExpression(IInvocationOperation invocationOperation);
 }

--- a/src/NSubstitute.Analyzers.Shared/DiagnosticAnalyzers/NonSubstitutableMemberAnalysis.cs
+++ b/src/NSubstitute.Analyzers.Shared/DiagnosticAnalyzers/NonSubstitutableMemberAnalysis.cs
@@ -1,0 +1,85 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
+using NSubstitute.Analyzers.Shared.Extensions;
+
+namespace NSubstitute.Analyzers.Shared.DiagnosticAnalyzers;
+
+internal class NonSubstitutableMemberAnalysis : INonSubstitutableMemberAnalysis
+{
+    public static INonSubstitutableMemberAnalysis Instance { get; } = new NonSubstitutableMemberAnalysis();
+
+    public NonSubstitutableMemberAnalysisResult Analyze(
+        in SyntaxNodeAnalysisContext syntaxNodeContext,
+        SyntaxNode accessedMember,
+        ISymbol symbol = null)
+    {
+        var accessedSymbol = symbol ?? syntaxNodeContext.SemanticModel.GetSymbolInfo(accessedMember).Symbol;
+
+        if (accessedSymbol == null)
+        {
+            return new NonSubstitutableMemberAnalysisResult(
+                nonVirtualMemberSubstitution: syntaxNodeContext.SemanticModel.GetOperation(accessedMember) is ILiteralOperation,
+                internalMemberSubstitution: false,
+                symbol: null,
+                member: accessedMember,
+                memberName: accessedMember.ToString());
+        }
+
+        var canBeSubstituted = CanBeSubstituted(syntaxNodeContext, accessedMember, accessedSymbol);
+
+        if (canBeSubstituted == false)
+        {
+            return new NonSubstitutableMemberAnalysisResult(
+                nonVirtualMemberSubstitution: true,
+                internalMemberSubstitution: false,
+                symbol: accessedSymbol,
+                member: accessedMember,
+                memberName: accessedSymbol.Name);
+        }
+
+        if (accessedSymbol.MemberVisibleToProxyGenerator() == false)
+        {
+            return new NonSubstitutableMemberAnalysisResult(
+                nonVirtualMemberSubstitution: false,
+                internalMemberSubstitution: true,
+                symbol: accessedSymbol,
+                member: accessedMember,
+                memberName: accessedSymbol.Name);
+        }
+
+        return new NonSubstitutableMemberAnalysisResult(
+            nonVirtualMemberSubstitution: false,
+            internalMemberSubstitution: false,
+            symbol: accessedSymbol,
+            member: accessedMember,
+            memberName: accessedSymbol.Name);
+    }
+
+    protected virtual bool CanBeSubstituted(
+        SyntaxNodeAnalysisContext syntaxNodeContext,
+        SyntaxNode accessedMember,
+        ISymbol symbol)
+    {
+        return CanBeSubstituted(symbol);
+    }
+
+    private static bool CanBeSubstituted(ISymbol symbol)
+    {
+        return IsInterfaceMember(symbol) || IsVirtual(symbol);
+    }
+
+    private static bool IsInterfaceMember(ISymbol symbol)
+    {
+        return symbol.ContainingType?.TypeKind == TypeKind.Interface;
+    }
+
+    private static bool IsVirtual(ISymbol symbol)
+    {
+        var isVirtual = symbol.IsVirtual
+                        || (symbol.IsOverride && !symbol.IsSealed)
+                        || symbol.IsAbstract;
+
+        return isVirtual;
+    }
+}

--- a/src/NSubstitute.Analyzers.Shared/Extensions/IOperationExtensions.cs
+++ b/src/NSubstitute.Analyzers.Shared/Extensions/IOperationExtensions.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Operations;
 
@@ -18,5 +20,68 @@ internal static class IOperationExtensions
             default:
                 return false;
         }
+    }
+
+    public static IOperation GetSubstituteOperation(this IInvocationOperation invocationOperation)
+    {
+        if (invocationOperation.Instance != null)
+        {
+            return invocationOperation.Instance;
+        }
+
+        return invocationOperation.Arguments.FirstOrDefault(arg => arg.Parameter.Ordinal == 0)?.Value;
+    }
+
+    public static IEnumerable<IArgumentOperation> GetOrderedArgumentOperations(
+        this IInvocationOperation invocationOperation)
+    {
+        return invocationOperation.Arguments.OrderBy(arg => arg.Parameter.Ordinal);
+    }
+
+    public static IEnumerable<IArgumentOperation> GetOrderedArgumentOperationsWithoutInstanceArgument(
+        this IInvocationOperation invocationOperation)
+    {
+        var orderedArguments = invocationOperation.GetOrderedArgumentOperations()
+            .Where(arg => IsImplicitlyProvidedArrayWithoutValues(arg) == false);
+
+        if (!invocationOperation.TargetMethod.IsExtensionMethod)
+        {
+            return orderedArguments;
+        }
+
+        // unlike CSharp implementation, VisualBasic doesnt include "instance" argument for reduced extensions
+        if (invocationOperation.TargetMethod.MethodKind == MethodKind.ReducedExtension &&
+            invocationOperation.Language == LanguageNames.VisualBasic)
+        {
+            return orderedArguments;
+        }
+
+        return orderedArguments.Skip(1);
+    }
+
+    public static IEnumerable<SyntaxNode> GetSyntaxes(this IArgumentOperation argumentOperation)
+    {
+        if (argumentOperation.Parameter.IsParams)
+        {
+            var initializerElementValues =
+                (argumentOperation.Value as IArrayCreationOperation)?.Initializer.ElementValues;
+
+            foreach (var operation in initializerElementValues ?? Enumerable.Empty<IOperation>())
+            {
+                yield return operation.Syntax;
+            }
+
+            yield break;
+        }
+
+        yield return argumentOperation.Value.Syntax;
+    }
+
+    private static bool IsImplicitlyProvidedArrayWithoutValues(IArgumentOperation arg)
+    {
+        return arg.IsImplicit &&
+               arg.ArgumentKind == ArgumentKind.ParamArray &&
+               arg.Value is IArrayCreationOperation arr &&
+               !arr.Initializer.ElementValues.Any();
     }
 }

--- a/src/NSubstitute.Analyzers.VisualBasic/DiagnosticAnalyzers/NonSubstitutableMemberAnalyzer.cs
+++ b/src/NSubstitute.Analyzers.VisualBasic/DiagnosticAnalyzers/NonSubstitutableMemberAnalyzer.cs
@@ -1,25 +1,14 @@
-using System.Collections.Immutable;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.VisualBasic;
-using Microsoft.CodeAnalysis.VisualBasic.Syntax;
 using NSubstitute.Analyzers.Shared.DiagnosticAnalyzers;
 
 namespace NSubstitute.Analyzers.VisualBasic.DiagnosticAnalyzers;
 
 [DiagnosticAnalyzer(LanguageNames.VisualBasic)]
-internal sealed class NonSubstitutableMemberAnalyzer : AbstractNonSubstitutableMemberAnalyzer<SyntaxKind, InvocationExpressionSyntax>
+internal sealed class NonSubstitutableMemberAnalyzer : AbstractNonSubstitutableMemberAnalyzer<SyntaxKind>
 {
     protected override SyntaxKind InvocationExpressionKind { get; } = SyntaxKind.InvocationExpression;
-
-    protected override ImmutableHashSet<int> SupportedMemberAccesses { get; } = ImmutableHashSet.Create(
-        (int)SyntaxKind.InvocationExpression,
-        (int)SyntaxKind.SimpleMemberAccessExpression,
-        (int)SyntaxKind.NumericLiteralExpression,
-        (int)SyntaxKind.CharacterLiteralExpression,
-        (int)SyntaxKind.FalseLiteralExpression,
-        (int)SyntaxKind.TrueLiteralExpression,
-        (int)SyntaxKind.StringLiteralExpression);
 
     public NonSubstitutableMemberAnalyzer()
         : base(NSubstitute.Analyzers.VisualBasic.DiagnosticDescriptorsProvider.Instance, SubstitutionNodeFinder.Instance, NonSubstitutableMemberAnalysis.Instance)

--- a/src/NSubstitute.Analyzers.VisualBasic/DiagnosticAnalyzers/NonSubstitutableMemberReceivedAnalyzer.cs
+++ b/src/NSubstitute.Analyzers.VisualBasic/DiagnosticAnalyzers/NonSubstitutableMemberReceivedAnalyzer.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Immutable;
-using Microsoft.CodeAnalysis;
+﻿using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.VisualBasic;
 using Microsoft.CodeAnalysis.VisualBasic.Syntax;
@@ -10,10 +9,6 @@ namespace NSubstitute.Analyzers.VisualBasic.DiagnosticAnalyzers;
 [DiagnosticAnalyzer(LanguageNames.VisualBasic)]
 internal sealed class NonSubstitutableMemberReceivedAnalyzer : AbstractNonSubstitutableMemberReceivedAnalyzer<SyntaxKind, MemberAccessExpressionSyntax>
 {
-    protected override ImmutableHashSet<int> PossibleParentsRawKinds { get; } = ImmutableHashSet.Create(
-        (int)SyntaxKind.SimpleMemberAccessExpression,
-        (int)SyntaxKind.InvocationExpression);
-
     protected override SyntaxKind InvocationExpressionKind { get; } = SyntaxKind.InvocationExpression;
 
     public NonSubstitutableMemberReceivedAnalyzer()

--- a/src/NSubstitute.Analyzers.VisualBasic/DiagnosticAnalyzers/NonSubstitutableMemberReceivedInOrderAnalyzer.cs
+++ b/src/NSubstitute.Analyzers.VisualBasic/DiagnosticAnalyzers/NonSubstitutableMemberReceivedInOrderAnalyzer.cs
@@ -8,7 +8,7 @@ using NSubstitute.Analyzers.Shared.DiagnosticAnalyzers;
 namespace NSubstitute.Analyzers.VisualBasic.DiagnosticAnalyzers;
 
 [DiagnosticAnalyzer(LanguageNames.VisualBasic)]
-internal sealed class NonSubstitutableMemberReceivedInOrderAnalyzer : AbstractNonSubstitutableMemberReceivedInOrderAnalyzer<SyntaxKind, InvocationExpressionSyntax, MemberAccessExpressionSyntax, LambdaExpressionSyntax>
+internal sealed class NonSubstitutableMemberReceivedInOrderAnalyzer : AbstractNonSubstitutableMemberReceivedInOrderAnalyzer<SyntaxKind, MemberAccessExpressionSyntax, LambdaExpressionSyntax>
 {
     private static ImmutableArray<int> IgnoredPaths { get; } = ImmutableArray.Create(
         (int)SyntaxKind.SimpleArgument,

--- a/src/NSubstitute.Analyzers.VisualBasic/DiagnosticAnalyzers/NonSubstitutableMemberWhenAnalyzer.cs
+++ b/src/NSubstitute.Analyzers.VisualBasic/DiagnosticAnalyzers/NonSubstitutableMemberWhenAnalyzer.cs
@@ -1,13 +1,12 @@
 ﻿using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.VisualBasic;
-using Microsoft.CodeAnalysis.VisualBasic.Syntax;
 using NSubstitute.Analyzers.Shared.DiagnosticAnalyzers;
 
 namespace NSubstitute.Analyzers.VisualBasic.DiagnosticAnalyzers;
 
 [DiagnosticAnalyzer(LanguageNames.VisualBasic)]
-internal sealed class NonSubstitutableMemberWhenAnalyzer : AbstractNonSubstitutableMemberWhenAnalyzer<SyntaxKind, InvocationExpressionSyntax>
+internal sealed class NonSubstitutableMemberWhenAnalyzer : AbstractNonSubstitutableMemberWhenAnalyzer<SyntaxKind>
 {
     public NonSubstitutableMemberWhenAnalyzer()
         : base(NSubstitute.Analyzers.VisualBasic.DiagnosticDescriptorsProvider.Instance, SubstitutionNodeFinder.Instance, NonSubstitutableMemberAnalysis.Instance)

--- a/src/NSubstitute.Analyzers.VisualBasic/DiagnosticAnalyzers/ReEntrantCallFinder.cs
+++ b/src/NSubstitute.Analyzers.VisualBasic/DiagnosticAnalyzers/ReEntrantCallFinder.cs
@@ -12,7 +12,7 @@ internal class ReEntrantCallFinder : AbstractReEntrantCallFinder<InvocationExpre
 {
     public static ReEntrantCallFinder Instance { get; } = new ReEntrantCallFinder(SubstitutionNodeFinder.Instance);
 
-    private ReEntrantCallFinder(ISubstitutionNodeFinder<InvocationExpressionSyntax> substitutionNodeFinder)
+    private ReEntrantCallFinder(ISubstitutionNodeFinder substitutionNodeFinder)
         : base(substitutionNodeFinder)
     {
     }

--- a/src/NSubstitute.Analyzers.VisualBasic/DiagnosticAnalyzers/ReceivedInReceivedInOrderAnalyzer.cs
+++ b/src/NSubstitute.Analyzers.VisualBasic/DiagnosticAnalyzers/ReceivedInReceivedInOrderAnalyzer.cs
@@ -1,13 +1,12 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.VisualBasic;
-using Microsoft.CodeAnalysis.VisualBasic.Syntax;
 using NSubstitute.Analyzers.Shared.DiagnosticAnalyzers;
 
 namespace NSubstitute.Analyzers.VisualBasic.DiagnosticAnalyzers;
 
 [DiagnosticAnalyzer(LanguageNames.VisualBasic)]
-internal sealed class ReceivedInReceivedInOrderAnalyzer : AbstractReceivedInReceivedInOrderAnalyzer<SyntaxKind, InvocationExpressionSyntax>
+internal sealed class ReceivedInReceivedInOrderAnalyzer : AbstractReceivedInReceivedInOrderAnalyzer<SyntaxKind>
 {
     public ReceivedInReceivedInOrderAnalyzer()
         : base(SubstitutionNodeFinder.Instance, VisualBasic.DiagnosticDescriptorsProvider.Instance)

--- a/tests/NSubstitute.Analyzers.Tests.CSharp/DiagnosticAnalyzerTests/CallInfoAnalyzerTests/AndDoesMethodPrecededByOrdinaryMethodTests.cs
+++ b/tests/NSubstitute.Analyzers.Tests.CSharp/DiagnosticAnalyzerTests/CallInfoAnalyzerTests/AndDoesMethodPrecededByOrdinaryMethodTests.cs
@@ -30,7 +30,17 @@ namespace MyNamespace
         {{
             var substitute = NSubstitute.Substitute.For<Foo>();
             var returnedValue = SubstituteExtensions.Returns({call}, 1);
+            var otherValue = SubstituteExtensions.Returns(value: {call}, returnThis: 1);
+            var yetAnotherValue = SubstituteExtensions.Returns(returnThis: 1, value: {call});
             returnedValue.{method}(callInfo =>
+            {{
+                {argAccess}
+            }});
+            otherValue.{method}(callInfo =>
+            {{
+                {argAccess}
+            }});
+            yetAnotherValue.{method}(callInfo =>
             {{
                 {argAccess}
             }});
@@ -66,6 +76,14 @@ namespace MyNamespace
             {{
                 {argAccess}
             }});
+            SubstituteExtensions.Returns(value: {call}, returnThis: 1).{method}(callInfo =>
+            {{
+                {argAccess}
+            }});
+            SubstituteExtensions.Returns(returnThis: 1, value: {call}).{method}(callInfo =>
+            {{
+                {argAccess}
+            }});
         }}
     }}
 }}";
@@ -98,6 +116,14 @@ namespace MyNamespace
             {{
                 {argAccess}
             }});
+            SubstituteExtensions.Returns(value: {call}, returnThis: 1).{method}(callInfo =>
+            {{
+                {argAccess}
+            }});
+            SubstituteExtensions.Returns(returnThis: 1, value: {call}).{method}(callInfo =>
+            {{
+                {argAccess}
+            }});
         }}
     }}
 }}";
@@ -126,6 +152,14 @@ namespace MyNamespace
         {{
             var substitute = NSubstitute.Substitute.For<Foo>();
             SubstituteExtensions.Returns({call}, 1).{method}(callInfo =>
+            {{
+                {argAccess}
+            }});
+            SubstituteExtensions.Returns(value: {call}, returnThis: 1).{method}(callInfo =>
+            {{
+                {argAccess}
+            }});
+            SubstituteExtensions.Returns(returnThis: 1, value: {call}).{method}(callInfo =>
             {{
                 {argAccess}
             }});
@@ -210,6 +244,14 @@ namespace MyNamespace
             {{
                 {argAccess}
             }});
+            SubstituteExtensions.Returns(value: {call}, returnThis: 1).{method}(callInfo =>
+            {{
+                {argAccess}
+            }});
+            SubstituteExtensions.Returns(returnThis: 1, value: {call}).{method}(callInfo =>
+            {{
+                {argAccess}
+            }});
         }}
     }}
 }}";
@@ -256,6 +298,14 @@ namespace MyNamespace
             {{
                 {argAccess}
             }});
+            SubstituteExtensions.Returns(value: {call}, returnThis: 1).{method}(callInfo =>
+            {{
+                {argAccess}
+            }});
+            SubstituteExtensions.Returns(returnThis: 1, value: {call}).{method}(callInfo =>
+            {{
+                {argAccess}
+            }});
         }}
     }}
 }}";
@@ -294,6 +344,14 @@ namespace MyNamespace
         {{
             var substitute = NSubstitute.Substitute.For<Foo>();
             SubstituteExtensions.Returns({call}, 1).{method}(callInfo =>
+            {{
+                {argAccess}
+            }});
+            SubstituteExtensions.Returns(value: {call}, returnThis: 1).{method}(callInfo =>
+            {{
+                {argAccess}
+            }});
+            SubstituteExtensions.Returns(returnThis: 1, value: {call}).{method}(callInfo =>
             {{
                 {argAccess}
             }});
@@ -343,6 +401,14 @@ namespace MyNamespace
             {{
                 {argAccess}
             }});
+            SubstituteExtensions.Returns(value: {call}, returnThis: 1).{method}(callInfo =>
+            {{
+                {argAccess}
+            }});
+            SubstituteExtensions.Returns(returnThis: 1, value: {call}).{method}(callInfo =>
+            {{
+                {argAccess}
+            }});
         }}
     }}
 }}";
@@ -373,6 +439,14 @@ namespace MyNamespace
         {{
             var substitute = NSubstitute.Substitute.For<Foo>();
             SubstituteExtensions.Returns({call}, 1).{method}(callInfo =>
+            {{
+                {argAccess}
+            }});
+            SubstituteExtensions.Returns(value: {call}, returnThis: 1).{method}(callInfo =>
+            {{
+                {argAccess}
+            }});
+            SubstituteExtensions.Returns(returnThis: 1, value: {call}).{method}(callInfo =>
             {{
                 {argAccess}
             }});
@@ -409,6 +483,14 @@ namespace MyNamespace
             {{
                 {argAccess}
             }});
+            SubstituteExtensions.Returns(value: {call}, returnThis: 1).{method}(callInfo =>
+            {{
+                {argAccess}
+            }});
+            SubstituteExtensions.Returns(returnThis: 1, value: {call}).{method}(callInfo =>
+            {{
+                {argAccess}
+            }});
         }}
     }}
 }}";
@@ -437,6 +519,14 @@ namespace MyNamespace
         {{
             var substitute = NSubstitute.Substitute.For<Foo>();
             SubstituteExtensions.Returns({call}, 1).{method}(callInfo =>
+            {{
+                {argAccess}
+            }});
+            SubstituteExtensions.Returns(value: {call}, returnThis: 1).{method}(callInfo =>
+            {{
+                {argAccess}
+            }});
+            SubstituteExtensions.Returns(returnThis: 1, value: {call}).{method}(callInfo =>
             {{
                 {argAccess}
             }});
@@ -583,6 +673,14 @@ namespace MyNamespace
             {{
                 {argAccess}
             }});
+            SubstituteExtensions.Returns(value: {call}, returnThis: 1).{method}(callInfo =>
+            {{
+                {argAccess}
+            }});
+            SubstituteExtensions.Returns(returnThis: 1, value: {call}).{method}(callInfo =>
+            {{
+                {argAccess}
+            }});
         }}
     }}
 }}";
@@ -659,6 +757,14 @@ namespace MyNamespace
             {{
                 {argAccess}
             }});
+            SubstituteExtensions.Returns(value: {call}, returnThis: 1).{method}(callInfo =>
+            {{
+                {argAccess}
+            }});
+            SubstituteExtensions.Returns(returnThis: 1, value: {call}).{method}(callInfo =>
+            {{
+                {argAccess}
+            }});
         }}
     }}
 }}";
@@ -695,6 +801,14 @@ namespace MyNamespace
             {{
                 {argAccess}
             }});
+            SubstituteExtensions.Returns(value: {call}, returnThis: 1).{method}(callInfo =>
+            {{
+                {argAccess}
+            }});
+            SubstituteExtensions.Returns(returnThis: 1, value: {call}).{method}(callInfo =>
+            {{
+                {argAccess}
+            }});
         }}
     }}
 }}";
@@ -721,6 +835,14 @@ namespace MyNamespace
         {{
             var substitute = NSubstitute.Substitute.For<Foo>();
             SubstituteExtensions.Returns({call}, 1).{method}(callInfo =>
+            {{
+                [|callInfo[1]|] = 1;
+            }});
+            SubstituteExtensions.Returns(value: {call}, returnThis: 1).{method}(callInfo =>
+            {{
+                [|callInfo[1]|] = 1;
+            }});
+            SubstituteExtensions.Returns(returnThis: 1, value: {call}).{method}(callInfo =>
             {{
                 [|callInfo[1]|] = 1;
             }});
@@ -751,6 +873,14 @@ namespace MyNamespace
             {{
                 callInfo[0] = 1;
             }});
+            SubstituteExtensions.Returns(value: substitute.Bar(ref value), returnThis: 1).{method}(callInfo =>
+            {{
+                callInfo[0] = 1;
+            }});
+            SubstituteExtensions.Returns(returnThis: 1, value: substitute.Bar(ref value)).{method}(callInfo =>
+            {{
+                callInfo[0] = 1;
+            }});
         }}
     }}
 }}";
@@ -778,6 +908,14 @@ namespace MyNamespace
             {{
                 callInfo[0] = 1;
             }});
+            SubstituteExtensions.Returns(value: substitute.Bar(out value), returnThis: 1).{method}(callInfo =>
+            {{
+                callInfo[0] = 1;
+            }});
+            SubstituteExtensions.Returns(returnThis: 1, value: substitute.Bar(out value)).{method}(callInfo =>
+            {{
+                callInfo[0] = 1;
+            }});
         }}
     }}
 }}";
@@ -802,6 +940,14 @@ namespace MyNamespace
             int value = 0;
             var substitute = NSubstitute.Substitute.For<Foo>();
             SubstituteExtensions.Returns(substitute.Bar(out value), 1).{method}(callInfo =>
+            {{
+                [|callInfo[1]|] = 1;
+            }});
+            SubstituteExtensions.Returns(value: substitute.Bar(out value), returnThis: 1).{method}(callInfo =>
+            {{
+                [|callInfo[1]|] = 1;
+            }});
+            SubstituteExtensions.Returns(returnThis: 1, value: substitute.Bar(out value)).{method}(callInfo =>
             {{
                 [|callInfo[1]|] = 1;
             }});
@@ -833,6 +979,14 @@ namespace MyNamespace
             {{
                 [|callInfo[0]|] = {right};
             }});
+            SubstituteExtensions.Returns(value: substitute.Bar(out value), returnThis: 1).{method}(callInfo =>
+            {{
+                [|callInfo[0]|] = {right};
+            }});
+            SubstituteExtensions.Returns(returnThis: 1, value: substitute.Bar(out value)).{method}(callInfo =>
+            {{
+                [|callInfo[0]|] = {right};
+            }});
         }}
     }}
 }}";
@@ -859,6 +1013,14 @@ namespace MyNamespace
             {left} value = default({left});
             var substitute = NSubstitute.Substitute.For<Foo>();
             SubstituteExtensions.Returns(substitute.Bar(out value), 1).{method}(callInfo =>
+            {{
+                callInfo[0] = {right};
+            }});
+            SubstituteExtensions.Returns(value: substitute.Bar(out value), returnThis: 1).{method}(callInfo =>
+            {{
+                callInfo[0] = {right};
+            }});
+            SubstituteExtensions.Returns(returnThis: 1, value: substitute.Bar(out value)).{method}(callInfo =>
             {{
                 callInfo[0] = {right};
             }});

--- a/tests/NSubstitute.Analyzers.Tests.CSharp/DiagnosticAnalyzerTests/CallInfoAnalyzerTests/DoMethodPrecededByOrdinaryMethodTests.cs
+++ b/tests/NSubstitute.Analyzers.Tests.CSharp/DiagnosticAnalyzerTests/CallInfoAnalyzerTests/DoMethodPrecededByOrdinaryMethodTests.cs
@@ -30,7 +30,17 @@ namespace MyNamespace
         {{
             var sub = NSubstitute.Substitute.For<Foo>();
             var returnValue = {method}(sub, substitute => {{var _ = {call}; }});
+            var otherValue = {method}(substitute: sub, substituteCall: substitute => {{var _ = {call}; }});
+            var yetAnotherValue = {method}(substituteCall: substitute => {{var _ = {call}; }}, substitute: sub);
             returnValue.Do(callInfo =>
+            {{
+                {argAccess}
+            }});
+            otherValue.Do(callInfo =>
+            {{
+                {argAccess}
+            }});
+            yetAnotherValue.Do(callInfo =>
             {{
                 {argAccess}
             }});
@@ -66,6 +76,14 @@ namespace MyNamespace
             {{
                 {argAccess}
             }});
+            {method}(substitute: sub, substituteCall: substitute => {{var _ = {call}; }}).Do(callInfo =>
+            {{
+                {argAccess}
+            }});
+            {method}(substituteCall: substitute => {{var _ = {call}; }}, substitute: sub).Do(callInfo =>
+            {{
+                {argAccess}
+            }});
         }}
     }}
 }}";
@@ -97,6 +115,14 @@ namespace MyNamespace
             {{
                 {argAccess}
             }});
+            {method}(substitute: sub, substituteCall: substitute => {{var _ = {call}; }}).Do(callInfo =>
+            {{
+                {argAccess}
+            }});
+            {method}(substituteCall: substitute => {{var _ = {call}; }}, substitute: sub).Do(callInfo =>
+            {{
+                {argAccess}
+            }});
         }}
     }}
 }}";
@@ -125,6 +151,14 @@ namespace MyNamespace
         {{
             var sub = NSubstitute.Substitute.For<Foo>();
             {method}(sub, substitute => {{var _ = {call}; }}).Do(callInfo =>
+            {{
+                {argAccess}
+            }});
+            {method}(substitute: sub, substituteCall: substitute => {{var _ = {call}; }}).Do(callInfo =>
+            {{
+                {argAccess}
+            }});
+            {method}(substituteCall: substitute => {{var _ = {call}; }}, substitute: sub).Do(callInfo =>
             {{
                 {argAccess}
             }});
@@ -208,6 +242,14 @@ namespace MyNamespace
             {{
                 {argAccess}
             }});
+            {method}(substitute: sub, substituteCall: substitute => {{var _ = {call}; }}).Do(callInfo =>
+            {{
+                {argAccess}
+            }});
+            {method}(substituteCall: substitute => {{var _ = {call}; }}, substitute: sub).Do(callInfo =>
+            {{
+                {argAccess}
+            }});
         }}
     }}
 }}";
@@ -254,6 +296,14 @@ namespace MyNamespace
             {{
                 {argAccess}
             }});
+            {method}(substitute: sub, substituteCall: substitute => {{var _ = {call}; }}).Do(callInfo =>
+            {{
+                {argAccess}
+            }});
+            {method}(substituteCall: substitute => {{var _ = {call}; }}, substitute: sub).Do(callInfo =>
+            {{
+                {argAccess}
+            }});
         }}
     }}
 }}";
@@ -293,6 +343,14 @@ namespace MyNamespace
         {{
             var sub = NSubstitute.Substitute.For<Foo>();
             {method}(sub, substitute => {{var _ = {call}; }}).Do(callInfo =>
+            {{
+                {argAccess}
+            }});
+            {method}(substitute: sub, substituteCall: substitute => {{var _ = {call}; }}).Do(callInfo =>
+            {{
+                {argAccess}
+            }});
+            {method}(substituteCall: substitute => {{var _ = {call}; }}, substitute: sub).Do(callInfo =>
             {{
                 {argAccess}
             }});
@@ -342,6 +400,14 @@ namespace MyNamespace
             {{
                 {argAccess}
             }});
+            {method}(substitute: sub, substituteCall: substitute => {{var _ = {call}; }}).Do(callInfo =>
+            {{
+                {argAccess}
+            }});
+            {method}(substituteCall: substitute => {{var _ = {call}; }}, substitute: sub).Do(callInfo =>
+            {{
+                {argAccess}
+            }});
         }}
     }}
 }}";
@@ -373,6 +439,14 @@ namespace MyNamespace
         {{
             var sub = NSubstitute.Substitute.For<Foo>();
             {method}(sub, substitute => {{var _ = {call}; }}).Do(callInfo =>
+            {{
+                {argAccess}
+            }});
+            {method}(substitute: sub, substituteCall: substitute => {{var _ = {call}; }}).Do(callInfo =>
+            {{
+                {argAccess}
+            }});
+            {method}(substituteCall: substitute => {{var _ = {call}; }}, substitute: sub).Do(callInfo =>
             {{
                 {argAccess}
             }});
@@ -409,6 +483,14 @@ namespace MyNamespace
             {{
                 {argAccess}
             }});
+            {method}(substitute: sub, substituteCall: substitute => {{var _ = {call}; }}).Do(callInfo =>
+            {{
+                {argAccess}
+            }});
+            {method}(substituteCall: substitute => {{var _ = {call}; }}, substitute: sub).Do(callInfo =>
+            {{
+                {argAccess}
+            }});
         }}
     }}
 }}";
@@ -437,6 +519,14 @@ namespace MyNamespace
         {{
             var sub = NSubstitute.Substitute.For<Foo>();
             {method}(sub, substitute => {{var _ = {call}; }}).Do(callInfo =>
+            {{
+                {argAccess}
+            }});
+            {method}(substitute: sub, substituteCall: substitute => {{var _ = {call}; }}).Do(callInfo =>
+            {{
+                {argAccess}
+            }});
+            {method}(substituteCall: substitute => {{var _ = {call}; }}, substitute: sub).Do(callInfo =>
             {{
                 {argAccess}
             }});
@@ -582,6 +672,14 @@ namespace MyNamespace
             {{
                 {argAccess}
             }});
+            {method}(substitute: sub, substituteCall: substitute => {{var _ = {call}; }}).Do(callInfo =>
+            {{
+                {argAccess}
+            }});
+            {method}(substituteCall: substitute => {{var _ = {call}; }}, substitute: sub).Do(callInfo =>
+            {{
+                {argAccess}
+            }});
         }}
     }}
 }}";
@@ -657,6 +755,14 @@ namespace MyNamespace
             {{
                 {argAccess}
             }});
+            {method}(substitute: sub, substituteCall: substitute => {{var _ = {call}; }}).Do(callInfo =>
+            {{
+                {argAccess}
+            }});
+            {method}(substituteCall: substitute => {{var _ = {call}; }}, substitute: sub).Do(callInfo =>
+            {{
+                {argAccess}
+            }});
         }}
     }}
 }}";
@@ -694,6 +800,14 @@ namespace MyNamespace
             {{
                 {argAccess}
             }});
+            {method}(substitute: sub, substituteCall: substitute => {{var _ = {call}; }}).Do(callInfo =>
+            {{
+                {argAccess}
+            }});
+            {method}(substituteCall: substitute => {{var _ = {call}; }}, substitute: sub).Do(callInfo =>
+            {{
+                {argAccess}
+            }});
         }}
     }}
 }}";
@@ -720,6 +834,14 @@ namespace MyNamespace
         {{
             var sub = NSubstitute.Substitute.For<Foo>();
             {method}(sub, substitute => {{var _ = {call}; }}).Do(callInfo =>
+            {{
+                [|callInfo[1]|] = 1;
+            }});
+            {method}(substitute: sub, substituteCall: substitute => {{var _ = {call}; }}).Do(callInfo =>
+            {{
+                [|callInfo[1]|] = 1;
+            }});
+            {method}(substituteCall: substitute => {{var _ = {call}; }}, substitute: sub).Do(callInfo =>
             {{
                 [|callInfo[1]|] = 1;
             }});
@@ -751,6 +873,14 @@ namespace MyNamespace
             {{
                 callInfo[0] = 1;
             }});
+            {method}(substitute: sub, substituteCall: substitute => {{var _ = substitute.Bar(ref value); }}).Do(callInfo =>
+            {{
+                callInfo[0] = 1;
+            }});
+            {method}(substituteCall: substitute => {{var _ = substitute.Bar(ref value); }}, substitute: sub).Do(callInfo =>
+            {{
+                callInfo[0] = 1;
+            }});
         }}
     }}
 }}";
@@ -778,6 +908,14 @@ namespace MyNamespace
             {{
                 callInfo[0] = 1;
             }});
+            {method}(substitute: sub, substituteCall: substitute => {{var _ = substitute.Bar(out value); }}).Do(callInfo =>
+            {{
+                callInfo[0] = 1;
+            }});
+            {method}(substituteCall: substitute => {{var _ = substitute.Bar(out value); }}, substitute: sub).Do(callInfo =>
+            {{
+                callInfo[0] = 1;
+            }});
         }}
     }}
 }}";
@@ -802,6 +940,14 @@ namespace MyNamespace
             int value = 0;
             var sub = NSubstitute.Substitute.For<Foo>();
             {method}(sub, substitute => {{var _ = substitute.Bar(out value); }}).Do(callInfo =>
+            {{
+                [|callInfo[1]|] = 1;
+            }});
+            {method}(substitute: sub, substituteCall: substitute => {{var _ = substitute.Bar(out value); }}).Do(callInfo =>
+            {{
+                [|callInfo[1]|] = 1;
+            }});
+            {method}(substituteCall: substitute => {{var _ = substitute.Bar(out value); }}, substitute: sub).Do(callInfo =>
             {{
                 [|callInfo[1]|] = 1;
             }});
@@ -835,6 +981,14 @@ namespace MyNamespace
             {{
                 [|callInfo[0]|] = {right};
             }});
+            {method}(substitute: sub, substituteCall: substitute => {{var _ = substitute.Bar(out value); }}).Do(callInfo =>
+            {{
+                [|callInfo[0]|] = {right};
+            }});
+            {method}(substituteCall: substitute => {{var _ = substitute.Bar(out value); }}, substitute: sub).Do(callInfo =>
+            {{
+                [|callInfo[0]|] = {right};
+            }});
         }}
     }}
 }}";
@@ -862,6 +1016,14 @@ namespace MyNamespace
             var sub = NSubstitute.Substitute.For<Foo>();
 
             {method}(sub, substitute => {{var _ = substitute.Bar(out value); }}).Do(callInfo =>
+            {{
+                callInfo[0] = {right};
+            }});
+            {method}(substitute: sub, substituteCall: substitute => {{var _ = substitute.Bar(out value); }}).Do(callInfo =>
+            {{
+                callInfo[0] = {right};
+            }});
+            {method}(substituteCall: substitute => {{var _ = substitute.Bar(out value); }}, substitute: sub).Do(callInfo =>
             {{
                 callInfo[0] = {right};
             }});

--- a/tests/NSubstitute.Analyzers.Tests.CSharp/DiagnosticAnalyzerTests/CallInfoAnalyzerTests/ReturnsAsOrdinaryMethodTests.cs
+++ b/tests/NSubstitute.Analyzers.Tests.CSharp/DiagnosticAnalyzerTests/CallInfoAnalyzerTests/ReturnsAsOrdinaryMethodTests.cs
@@ -35,6 +35,16 @@ namespace MyNamespace
                 {argAccess}
                 return 1;
             }});
+            {method}(value: returnedValue, returnThis: callInfo =>
+            {{
+                {argAccess}
+                return 1;
+            }});
+            {method}(returnThis: callInfo =>
+            {{
+                {argAccess}
+                return 1;
+            }}, value: returnedValue);
         }}
     }}
 }}";
@@ -68,6 +78,16 @@ namespace MyNamespace
                 {argAccess}
                 return 1;
             }});
+            {method}(value: {call}, returnThis: callInfo =>
+            {{
+                {argAccess}
+                return 1;
+            }});
+            {method}(returnThis: callInfo =>
+            {{
+                {argAccess}
+                return 1;
+            }}, value: {call});
         }}
     }}
 }}";
@@ -101,6 +121,16 @@ namespace MyNamespace
                 {argAccess}
                 return 1;
             }});
+            {method}(value: {call}, returnThis: callInfo =>
+            {{
+                {argAccess}
+                return 1;
+            }});
+            {method}(returnThis: callInfo =>
+            {{
+                {argAccess}
+                return 1;
+            }}, value: {call});
         }}
     }}
 }}";
@@ -133,6 +163,16 @@ namespace MyNamespace
                 {argAccess}
                 return 1;
             }});
+            {method}(value: {call}, returnThis: callInfo =>
+            {{
+                {argAccess}
+                return 1;
+            }});
+            {method}(returnThis: callInfo =>
+            {{
+                {argAccess}
+                return 1;
+            }}, value: {call});
         }}
     }}
 }}";
@@ -216,6 +256,16 @@ namespace MyNamespace
                 {argAccess}
                 return 1;
             }});
+            {method}(value: {call}, returnThis: callInfo =>
+            {{
+                {argAccess}
+                return 1;
+            }});
+            {method}(returnThis: callInfo =>
+            {{
+                {argAccess}
+                return 1;
+            }}, value: {call});
         }}
     }}
 }}";
@@ -263,6 +313,16 @@ namespace MyNamespace
                 {argAccess}
                 return 1;
             }});
+            {method}(value: {call}, returnThis: callInfo =>
+            {{
+                {argAccess}
+                return 1;
+            }});
+            {method}(returnThis: callInfo =>
+            {{
+                {argAccess}
+                return 1;
+            }}, value: {call});
         }}
     }}
 }}";
@@ -305,6 +365,16 @@ namespace MyNamespace
                 {argAccess}
                 return 1;
             }});
+            {method}(value: {call}, returnThis: callInfo =>
+            {{
+                {argAccess}
+                return 1;
+            }});
+            {method}(returnThis: callInfo =>
+            {{
+                {argAccess}
+                return 1;
+            }}, value: {call});
         }}
     }}
 }}";
@@ -352,6 +422,16 @@ namespace MyNamespace
                 {argAccess}
                 return 1;
             }});
+            {method}(value: {call}, returnThis: callInfo =>
+            {{
+                {argAccess}
+                return 1;
+            }});
+            {method}(returnThis: callInfo =>
+            {{
+                {argAccess}
+                return 1;
+            }}, value: {call});
         }}
     }}
 }}";
@@ -386,6 +466,16 @@ namespace MyNamespace
                 {argAccess}
                 return 1;
             }});
+            {method}(value: {call}, returnThis: callInfo =>
+            {{
+                {argAccess}
+                return 1;
+            }});
+            {method}(returnThis: callInfo =>
+            {{
+                {argAccess}
+                return 1;
+            }}, value: {call});
         }}
     }}
 }}";
@@ -420,6 +510,16 @@ namespace MyNamespace
                 {argAccess}
                 return 1;
             }});
+            {method}(value: {call}, returnThis: callInfo =>
+            {{
+                {argAccess}
+                return 1;
+            }});
+            {method}(returnThis: callInfo =>
+            {{
+                {argAccess}
+                return 1;
+            }}, value: {call});
         }}
     }}
 }}";
@@ -452,6 +552,16 @@ namespace MyNamespace
                 {argAccess}
                 return 1;
             }});
+            {method}(value: {call}, returnThis: callInfo =>
+            {{
+                {argAccess}
+                return 1;
+            }});
+            {method}(returnThis: callInfo =>
+            {{
+                {argAccess}
+                return 1;
+            }}, value: {call});
         }}
     }}
 }}";
@@ -598,6 +708,16 @@ namespace MyNamespace
                 {argAccess}
                 return 1;
             }});
+            {method}(value: {call}, returnThis: callInfo =>
+            {{
+                {argAccess}
+                return 1;
+            }});
+            {method}(returnThis: callInfo =>
+            {{
+                {argAccess}
+                return 1;
+            }}, value: {call});
         }}
     }}
 }}";
@@ -676,6 +796,16 @@ namespace MyNamespace
                 {argAccess}
                 return 1;
             }});
+            {method}(value: {call}, returnThis: callInfo =>
+            {{
+                {argAccess}
+                return 1;
+            }});
+            {method}(returnThis: callInfo =>
+            {{
+                {argAccess}
+                return 1;
+            }}, value: {call});
         }}
     }}
 }}";
@@ -713,6 +843,16 @@ namespace MyNamespace
                 {argAccess}
                 return 1;
             }});
+            {method}(value: {call}, returnThis: callInfo =>
+            {{
+                {argAccess}
+                return 1;
+            }});
+            {method}(returnThis: callInfo =>
+            {{
+                {argAccess}
+                return 1;
+            }}, value: {call});
         }}
     }}
 }}";
@@ -743,6 +883,16 @@ namespace MyNamespace
                 [|callInfo[1]|] = 1;
                 return 1;
             }});
+            {method}(value: {call}, returnThis: callInfo =>
+            {{
+                [|callInfo[1]|] = 1;
+                return 1;
+            }});
+            {method}(returnThis: callInfo =>
+            {{
+                [|callInfo[1]|] = 1;
+                return 1;
+            }}, value: {call});
         }}
     }}
 }}";
@@ -771,6 +921,16 @@ namespace MyNamespace
                 callInfo[0] = 1;
                 return 1;
             }});
+            {method}(value: substitute.Bar(ref value), returnThis: callInfo =>
+            {{
+                callInfo[0] = 1;
+                return 1;
+            }});
+            {method}(returnThis: callInfo =>
+            {{
+                callInfo[0] = 1;
+                return 1;
+            }}, value: substitute.Bar(ref value));
         }}
     }}
 }}";
@@ -799,6 +959,16 @@ namespace MyNamespace
                 callInfo[0] = 1;
                 return 1;
             }});
+            {method}(value: substitute.Bar(out value), returnThis: callInfo =>
+            {{
+                callInfo[0] = 1;
+                return 1;
+            }});
+            {method}(returnThis: callInfo =>
+            {{
+                callInfo[0] = 1;
+                return 1;
+            }}, value: substitute.Bar(out value));
         }}
     }}
 }}";
@@ -827,6 +997,16 @@ namespace MyNamespace
                 [|callInfo[1]|] = 1;
                 return 1;
             }});
+            {method}(value: substitute.Bar(out value), returnThis:callInfo =>
+            {{
+                [|callInfo[1]|] = 1;
+                return 1;
+            }});
+            {method}(returnThis:callInfo =>
+            {{
+                [|callInfo[1]|] = 1;
+                return 1;
+            }}, value: substitute.Bar(out value));
         }}
     }}
 }}";
@@ -856,6 +1036,16 @@ namespace MyNamespace
                 [|callInfo[0]|] = {right};
                 return 1;
             }});
+            {method}(value: substitute.Bar(out value), returnThis: callInfo =>
+            {{
+                [|callInfo[0]|] = {right};
+                return 1;
+            }});
+            {method}(returnThis: callInfo =>
+            {{
+                [|callInfo[0]|] = {right};
+                return 1;
+            }}, value: substitute.Bar(out value));
         }}
     }}
 }}";
@@ -886,6 +1076,16 @@ namespace MyNamespace
                 callInfo[0] = {right};
                 return 1;
             }});
+            {method}(value: substitute.Bar(out value), returnThis: callInfo =>
+            {{
+                callInfo[0] = {right};
+                return 1;
+            }});
+            {method}(returnThis: callInfo =>
+            {{
+                callInfo[0] = {right};
+                return 1;
+            }}, value: substitute.Bar(out value));
         }}
     }}
 }}";

--- a/tests/NSubstitute.Analyzers.Tests.CSharp/DiagnosticAnalyzerTests/CallInfoAnalyzerTests/ThrowsAsOrdinaryMethodTests.cs
+++ b/tests/NSubstitute.Analyzers.Tests.CSharp/DiagnosticAnalyzerTests/CallInfoAnalyzerTests/ThrowsAsOrdinaryMethodTests.cs
@@ -36,6 +36,16 @@ namespace MyNamespace
                 {argAccess}
                 return new Exception();
             }});
+            {method}(value: returnedValue, createException: callInfo =>
+            {{
+                {argAccess}
+                return new Exception();
+            }});
+            {method}(createException: callInfo =>
+            {{
+                {argAccess}
+                return new Exception();
+            }}, value: returnedValue);
         }}
     }}
 }}";
@@ -69,6 +79,16 @@ namespace MyNamespace
                 {argAccess}
                 return new Exception();
             }});
+            {method}(value: {call}, createException: callInfo =>
+            {{
+                {argAccess}
+                return new Exception();
+            }});
+            {method}(createException: callInfo =>
+            {{
+                {argAccess}
+                return new Exception();
+            }}, value: {call});
         }}
     }}
 }}";
@@ -103,6 +123,16 @@ namespace MyNamespace
                 {argAccess}
                 return new Exception();
             }});
+            {method}(value: {call}, createException: callInfo =>
+            {{
+                {argAccess}
+                return new Exception();
+            }});
+            {method}(createException: callInfo =>
+            {{
+                {argAccess}
+                return new Exception();
+            }}, value: {call});
         }}
     }}
 }}";
@@ -136,6 +166,16 @@ namespace MyNamespace
                 {argAccess}
                 return new Exception();
             }});
+            {method}(value: {call}, createException: callInfo =>
+            {{
+                {argAccess}
+                return new Exception();
+            }});
+            {method}(createException: callInfo =>
+            {{
+                {argAccess}
+                return new Exception();
+            }}, value: {call});
         }}
     }}
 }}";
@@ -221,6 +261,16 @@ namespace MyNamespace
                 {argAccess}
                 return new Exception();
             }});
+            {method}(value: {call}, createException: callInfo =>
+            {{
+                {argAccess}
+                return new Exception();
+            }});
+            {method}(createException: callInfo =>
+            {{
+                {argAccess}
+                return new Exception();
+            }}, value: {call});
         }}
     }}
 }}";
@@ -268,6 +318,16 @@ namespace MyNamespace
                 {argAccess}
                 return new Exception();
             }});
+            {method}(value: {call}, createException: callInfo =>
+            {{
+                {argAccess}
+                return new Exception();
+            }});
+            {method}(createException: callInfo =>
+            {{
+                {argAccess}
+                return new Exception();
+            }}, value: {call});
         }}
     }}
 }}";
@@ -311,6 +371,16 @@ namespace MyNamespace
                 {argAccess}
                 return new Exception();
             }});
+            {method}(value: {call}, createException: callInfo =>
+            {{
+                {argAccess}
+                return new Exception();
+            }});
+            {method}(createException: callInfo =>
+            {{
+                {argAccess}
+                return new Exception();
+            }}, value: {call});
         }}
     }}
 }}";
@@ -358,6 +428,16 @@ namespace MyNamespace
                 {argAccess}
                 return new Exception();
             }});
+            {method}(value: {call}, createException: callInfo =>
+            {{
+                {argAccess}
+                return new Exception();
+            }});
+            {method}(createException: callInfo =>
+            {{
+                {argAccess}
+                return new Exception();
+            }}, value: {call});
         }}
     }}
 }}";
@@ -393,6 +473,16 @@ namespace MyNamespace
                 {argAccess}
                 return new Exception();
             }});
+            {method}(value: {call}, createException: callInfo =>
+            {{
+                {argAccess}
+                return new Exception();
+            }});
+            {method}(createException: callInfo =>
+            {{
+                {argAccess}
+                return new Exception();
+            }}, value: {call});
         }}
     }}
 }}";
@@ -428,6 +518,16 @@ namespace MyNamespace
                 {argAccess}
                 return new Exception();
             }});
+            {method}(value: {call}, createException: callInfo =>
+            {{
+                {argAccess}
+                return new Exception();
+            }});
+            {method}(createException: callInfo =>
+            {{
+                {argAccess}
+                return new Exception();
+            }}, value: {call});
         }}
     }}
 }}";
@@ -461,6 +561,16 @@ namespace MyNamespace
                 {argAccess}
                 return new Exception();
             }});
+            {method}(value: {call}, createException: callInfo =>
+            {{
+                {argAccess}
+                return new Exception();
+            }});
+            {method}(createException: callInfo =>
+            {{
+                {argAccess}
+                return new Exception();
+            }}, value: {call});
         }}
     }}
 }}";
@@ -610,6 +720,16 @@ namespace MyNamespace
                 {argAccess}
                 return new Exception();
             }});
+            {method}(value: {call}, createException: callInfo =>
+            {{
+                {argAccess}
+                return new Exception();
+            }});
+            {method}(createException: callInfo =>
+            {{
+                {argAccess}
+                return new Exception();
+            }}, value: {call});
         }}
     }}
 }}";
@@ -692,6 +812,16 @@ namespace MyNamespace
                 {argAccess}
                 return new Exception();
             }});
+            {method}(value: {call}, createException: callInfo =>
+            {{
+                {argAccess}
+                return new Exception();
+            }});
+            {method}(createException: callInfo =>
+            {{
+                {argAccess}
+                return new Exception();
+            }}, value: {call});
         }}
     }}
 }}";
@@ -732,6 +862,16 @@ namespace MyNamespace
                 {argAccess}
                 return new Exception();
             }});
+            {method}(value: {call}, createException: callInfo =>
+            {{
+                {argAccess}
+                return new Exception();
+            }});
+            {method}(createException: callInfo =>
+            {{
+                {argAccess}
+                return new Exception();
+            }}, value: {call});
         }}
     }}
 }}";
@@ -764,6 +904,16 @@ namespace MyNamespace
                 [|callInfo[1]|] = 1;
                 return new Exception();
             }});
+            {method}(value: {call}, createException: callInfo =>
+            {{
+                [|callInfo[1]|] = 1;
+                return new Exception();
+            }});
+            {method}(createException: callInfo =>
+            {{
+                [|callInfo[1]|] = 1;
+                return new Exception();
+            }}, value: {call});
         }}
     }}
 }}";
@@ -795,6 +945,16 @@ namespace MyNamespace
                 callInfo[0] = 1;
                 return new Exception();
             }});
+            {method}(value: substitute.Bar(ref value), createException: callInfo =>
+            {{
+                callInfo[0] = 1;
+                return new Exception();
+            }});
+            {method}(createException: callInfo =>
+            {{
+                callInfo[0] = 1;
+                return new Exception();
+            }}, value: substitute.Bar(ref value));
         }}
     }}
 }}";
@@ -825,6 +985,16 @@ namespace MyNamespace
                 callInfo[0] = 1;
                 return new Exception();
             }});
+            {method}(value: substitute.Bar(out value), createException: callInfo =>
+            {{
+                callInfo[0] = 1;
+                return new Exception();
+            }});
+            {method}(createException: callInfo =>
+            {{
+                callInfo[0] = 1;
+                return new Exception();
+            }}, value: substitute.Bar(out value));
         }}
     }}
 }}";
@@ -855,6 +1025,16 @@ namespace MyNamespace
                 [|callInfo[1]|] = 1;
                 return new Exception();
             }});
+            {method}(value: substitute.Bar(out value), createException: callInfo =>
+            {{
+                [|callInfo[1]|] = 1;
+                return new Exception();
+            }});
+            {method}(createException: callInfo =>
+            {{
+                [|callInfo[1]|] = 1;
+                return new Exception();
+            }}, value: substitute.Bar(out value));
         }}
     }}
 }}";
@@ -886,6 +1066,16 @@ namespace MyNamespace
                 [|callInfo[0]|] = {right};
                 return new Exception();
             }});
+            {method}(value: substitute.Bar(out value), createException: callInfo =>
+            {{
+                [|callInfo[0]|] = {right};
+                return new Exception();
+            }});
+            {method}(createException: callInfo =>
+            {{
+                [|callInfo[0]|] = {right};
+                return new Exception();
+            }}, value: substitute.Bar(out value));
         }}
     }}
 }}";
@@ -918,6 +1108,16 @@ namespace MyNamespace
                 callInfo[0] = {right};
                 return new Exception();
             }});
+            {method}(value: substitute.Bar(out value), createException: callInfo =>
+            {{
+                callInfo[0] = {right};
+                return new Exception();
+            }});
+            {method}(createException: callInfo =>
+            {{
+                callInfo[0] = {right};
+                return new Exception();
+            }}, value: substitute.Bar(out value));
         }}
     }}
 }}";

--- a/tests/NSubstitute.Analyzers.Tests.CSharp/DiagnosticAnalyzerTests/NonSubstitutableMemberAnalyzerTests/ReturnsAsOrdinaryMethodTests.cs
+++ b/tests/NSubstitute.Analyzers.Tests.CSharp/DiagnosticAnalyzerTests/NonSubstitutableMemberAnalyzerTests/ReturnsAsOrdinaryMethodTests.cs
@@ -29,6 +29,8 @@ namespace MyNamespace
         {{
             var substitute = NSubstitute.Substitute.For<Foo>();
             {method}([|substitute.Bar()|], 1);
+            {method}(value: [|substitute.Bar()|], returnThis: 1);
+            {method}(returnThis: 1, value: [|substitute.Bar()|]);
         }}
     }}
 }}";
@@ -50,6 +52,8 @@ namespace MyNamespace
         public void Test()
         {{
             {method}([|{literal}|], {literal});
+            {method}(value: [|{literal}|], returnThis: {literal});
+            {method}(returnThis: {literal}, value: [|{literal}|]);
         }}
     }}
 }}";
@@ -76,6 +80,8 @@ namespace MyNamespace
         public void Test()
         {{
             {method}([|Foo.Bar()|], 1);
+            {method}(value: [|Foo.Bar()|], returnThis: 1);
+            {method}(returnThis: 1, value: [|Foo.Bar()|]);
         }}
     }}
 }}";
@@ -103,6 +109,8 @@ namespace MyNamespace
         {{
             var substitute = NSubstitute.Substitute.For<Foo>();
             {method}(substitute.Bar(), 1);
+            {method}(value: substitute.Bar(), returnThis: 1);
+            {method}(returnThis: 1, value: substitute.Bar());
         }}
     }}
 }}";
@@ -134,6 +142,8 @@ namespace MyNamespace
         {{
             var substitute = NSubstitute.Substitute.For<Foo2>();
             {method}(substitute.Bar(), 1);
+            {method}(value: substitute.Bar(), returnThis: 1);
+            {method}(returnThis: 1, value: substitute.Bar());
         }}
     }}
 }}";
@@ -161,6 +171,8 @@ namespace MyNamespace
             var substitute = NSubstitute.Substitute.For<Foo>();
             var returnValue = substitute.Bar();
             {method}(returnValue, 1);
+            {method}(value: returnValue, returnThis: 1);
+            {method}(returnThis: 1, value: returnValue);
         }}
     }}
 }}";
@@ -180,6 +192,8 @@ namespace MyNamespace
         {{
             var substitute = Substitute.For<Func<int>>();
             {method}(substitute(), 1);
+            {method}(value: substitute(), returnThis: 1);
+            {method}(returnThis: 1, value: substitute());
         }}
     }}
 }}";
@@ -211,6 +225,8 @@ namespace MyNamespace
         {{
             var substitute = NSubstitute.Substitute.For<Foo2>();
             {method}([|substitute.Bar()|], 1);
+            {method}(value: [|substitute.Bar()|], returnThis: 1);
+            {method}(returnThis: 1, value: [|substitute.Bar()|]);
         }}
     }}
 }}";
@@ -235,6 +251,8 @@ namespace MyNamespace
         {{
             var substitute = NSubstitute.Substitute.For<Foo>();
             {method}(substitute.Bar(), 1);
+            {method}(value: substitute.Bar(), returnThis: 1);
+            {method}(returnThis: 1, value: substitute.Bar());
         }}
     }}
 }}";
@@ -259,6 +277,8 @@ namespace MyNamespace
         {{
             var substitute = NSubstitute.Substitute.For<IFoo>();
             {method}(substitute.Bar(), 1);
+            {method}(value: substitute.Bar(), returnThis: 1);
+            {method}(returnThis: 1, value: substitute.Bar());
         }}
     }}
 }}";
@@ -282,6 +302,8 @@ namespace MyNamespace
         {{
             var substitute = NSubstitute.Substitute.For<IFoo>();
             {method}(substitute.Bar, 1);
+            {method}(value: substitute.Bar, returnThis: 1);
+            {method}(returnThis: 1, value: substitute.Bar);
         }}
     }}
 }}";
@@ -305,6 +327,8 @@ namespace MyNamespace
         {{
             var substitute = NSubstitute.Substitute.For<IFoo<int>>();
             {method}(substitute.Bar<int>(), 1);
+            {method}(value: substitute.Bar<int>(), returnThis: 1);
+            {method}(returnThis: 1, value: substitute.Bar<int>());
         }}
     }}
 }}";
@@ -328,6 +352,8 @@ namespace MyNamespace
         {{
             var substitute = NSubstitute.Substitute.For<Foo>();
             {method}(substitute.Bar, 1);
+            {method}(value: substitute.Bar, returnThis: 1);
+            {method}(returnThis: 1, value: substitute.Bar);
         }}
     }}
 }}";
@@ -352,6 +378,8 @@ namespace MyNamespace
         {{
             var substitute = NSubstitute.Substitute.For<IFoo>();
             {method}(substitute[1], 1);
+            {method}(value: substitute[1], returnThis: 1);
+            {method}(returnThis: 1, value: substitute[1]);
         }}
     }}
 }}";
@@ -375,6 +403,8 @@ namespace MyNamespace
         {{
             var substitute = NSubstitute.Substitute.For<Foo>();
             {method}(substitute.Bar, 1);
+            {method}(value: substitute.Bar, returnThis: 1);
+            {method}(returnThis: 1, value: substitute.Bar);
         }}
     }}
 }}";
@@ -399,6 +429,8 @@ namespace MyNamespace
         {{
             var substitute = NSubstitute.Substitute.For<Foo>();
             {method}([|substitute.Bar|], 1);
+            {method}(value: [|substitute.Bar|], returnThis: 1);
+            {method}(returnThis: 1, value: [|substitute.Bar|]);
         }}
     }}
 }}";
@@ -423,6 +455,8 @@ namespace MyNamespace
         {{
             var substitute = NSubstitute.Substitute.For<Foo>();
             {method}(substitute[1], 1);
+            {method}(value: substitute[1], returnThis: 1);
+            {method}(returnThis: 1, value: substitute[1]);
         }}
     }}
 }}";
@@ -446,6 +480,8 @@ namespace MyNamespace
         {{
             var substitute = NSubstitute.Substitute.For<Foo>();
             {method}([|substitute[1]|], 1);
+            {method}(value: [|substitute[1]|], returnThis: 1);
+            {method}(returnThis: 1, value: [|substitute[1]|]);
         }}
     }}
 }}";
@@ -469,12 +505,12 @@ namespace NSubstitute
 
     public static class SubstituteExtensions
     {{
-        public static T Returns<T>(this T returnValue, T returnThis)
+        public static T Returns<T>(this T value, T returnThis)
         {{
             return default(T);
         }}
 
-        public static T ReturnsForAnyArgs<T>(this T returnValue, T returnThis)
+        public static T ReturnsForAnyArgs<T>(this T value, T returnThis)
         {{
             return default(T);
         }}
@@ -486,6 +522,8 @@ namespace NSubstitute
         {{
             Foo substitute = null;
             {method}(substitute.Bar(), 1);
+            {method}(value: substitute.Bar(), returnThis: 1);
+            {method}(returnThis: 1, value: substitute.Bar());
         }}
     }}
 }}";
@@ -927,6 +965,8 @@ namespace MyNamespace
         {{
             var substitute = NSubstitute.Substitute.For<Foo>();
             var x = {method}([|substitute{call}|], 1);
+            var y = {method}(value: [|substitute{call}|], returnThis: 1);
+            var z = {method}(returnThis: 1, value: [|substitute{call}|]);
         }}
     }}
 }}";
@@ -965,6 +1005,8 @@ namespace MyNamespace
         {{
             var substitute = NSubstitute.Substitute.For<Foo>();
             var x = {method}(substitute{call}, 1);
+            var y = {method}(value: substitute{call}, returnThis: 1);
+            var z = {method}(returnThis: 1, value: substitute{call});
         }}
     }}
 }}";
@@ -1001,6 +1043,8 @@ namespace MyNamespace
         {{
             var substitute = NSubstitute.Substitute.For<Foo>();
             var x = {method}([|substitute{call}|], 1);
+            var y = {method}(value: [|substitute{call}|], returnThis: 1);
+            var u = {method}(returnThis: 1, value: [|substitute{call}|]);
         }}
     }}
 }}";
@@ -1035,6 +1079,8 @@ namespace MyNamespace
         {{
             var substitute = NSubstitute.Substitute.For<Foo>();
             var x = {method}(substitute{call}, 1);
+            var y = {method}(value: substitute{call}, returnThis: 1);
+            var z = {method}(returnThis: 1, value: substitute{call});
         }}
     }}
 }}";

--- a/tests/NSubstitute.Analyzers.Tests.CSharp/DiagnosticAnalyzerTests/NonSubstitutableMemberAnalyzerTests/ThrowsAsOrdinaryMethodTests.cs
+++ b/tests/NSubstitute.Analyzers.Tests.CSharp/DiagnosticAnalyzerTests/NonSubstitutableMemberAnalyzerTests/ThrowsAsOrdinaryMethodTests.cs
@@ -30,7 +30,8 @@ namespace MyNamespace
         public void Test()
         {{
             var substitute = NSubstitute.Substitute.For<Foo>();
-            {method}([|substitute.Bar()|], new Exception());
+            {method}(value: [|substitute.Bar()|], ex: new Exception());
+            {method}(ex: new Exception(), value: [|substitute.Bar()|]);
         }}
     }}
 }}";
@@ -51,6 +52,8 @@ namespace MyNamespace
         public void Test()
         {{
             {method}([|{literal}|], new Exception());
+            {method}(value: [|{literal}|], ex: new Exception());
+            {method}(ex: new Exception(), value: [|{literal}|]);
         }}
     }}
 }}";
@@ -79,6 +82,8 @@ namespace MyNamespace
         public void Test()
         {{
             {method}([|Foo.Bar()|], new Exception());
+            {method}(value: [|Foo.Bar()|], ex: new Exception());
+            {method}(ex: new Exception(), value: [|Foo.Bar()|]);
         }}
     }}
 }}";
@@ -108,6 +113,8 @@ namespace MyNamespace
         {{
             var substitute = NSubstitute.Substitute.For<Foo>();
             {method}(substitute.Bar(), new Exception());
+            {method}(value: substitute.Bar(), ex: new Exception());
+            {method}(ex: new Exception(), value: substitute.Bar());
         }}
     }}
 }}";
@@ -141,6 +148,8 @@ namespace MyNamespace
         {{
             var substitute = NSubstitute.Substitute.For<Foo2>();
             {method}(substitute.Bar(), new Exception());
+            {method}(value: substitute.Bar(), ex: new Exception());
+            {method}(ex: new Exception(), value: substitute.Bar());
         }}
     }}
 }}";
@@ -170,6 +179,8 @@ namespace MyNamespace
             var substitute = NSubstitute.Substitute.For<Foo>();
             var returnValue = substitute.Bar();
             {method}(returnValue, new Exception());
+            {method}(value: returnValue, ex: new Exception());
+            {method}(ex: new Exception(), value: returnValue);
         }}
     }}
 }}";
@@ -191,6 +202,8 @@ namespace MyNamespace
         {{
             var substitute = Substitute.For<Func<int>>();
             {method}(substitute(), new Exception());
+            {method}(value: substitute(), ex: new Exception());
+            {method}(ex: new Exception(), value: substitute());
         }}
     }}
 }}";
@@ -224,6 +237,8 @@ namespace MyNamespace
         {{
             var substitute = NSubstitute.Substitute.For<Foo2>();
             {method}([|substitute.Bar()|], new Exception());
+            {method}(value: [|substitute.Bar()|], ex: new Exception());
+            {method}(ex: new Exception(), value: [|substitute.Bar()|]);
         }}
     }}
 }}";
@@ -250,6 +265,8 @@ namespace MyNamespace
         {{
             var substitute = NSubstitute.Substitute.For<Foo>();
             {method}(substitute.Bar(), new Exception());
+            {method}(value: substitute.Bar(), ex: new Exception());
+            {method}(ex: new Exception(), value: substitute.Bar());
         }}
     }}
 }}";
@@ -276,6 +293,8 @@ namespace MyNamespace
         {{
             var substitute = NSubstitute.Substitute.For<IFoo>();
             {method}(substitute.Bar(), new Exception());
+            {method}(value: substitute.Bar(), ex: new Exception());
+            {method}(ex: new Exception(), value: substitute.Bar());
         }}
     }}
 }}";
@@ -301,6 +320,8 @@ namespace MyNamespace
         {{
             var substitute = NSubstitute.Substitute.For<IFoo>();
             {method}(substitute.Bar, new Exception());
+            {method}(value: substitute.Bar, ex: new Exception());
+            {method}(ex: new Exception(), value: substitute.Bar);
         }}
     }}
 }}";
@@ -326,6 +347,8 @@ namespace MyNamespace
         {{
             var substitute = NSubstitute.Substitute.For<IFoo<int>>();
             {method}(substitute.Bar<int>(), new Exception());
+            {method}(value: substitute.Bar<int>(), ex: new Exception());
+            {method}(ex: new Exception(), value: substitute.Bar<int>());
         }}
     }}
 }}";
@@ -351,6 +374,8 @@ namespace MyNamespace
         {{
             var substitute = NSubstitute.Substitute.For<Foo>();
             {method}(substitute.Bar, new Exception());
+            {method}(value: substitute.Bar, ex: new Exception());
+            {method}(ex: new Exception(), value: substitute.Bar);
         }}
     }}
 }}";
@@ -377,6 +402,8 @@ namespace MyNamespace
         {{
             var substitute = NSubstitute.Substitute.For<IFoo>();
             {method}(substitute[1], new Exception());
+            {method}(value: substitute[1], ex: new Exception());
+            {method}(ex: new Exception(), value: substitute[1]);
         }}
     }}
 }}";
@@ -402,6 +429,8 @@ namespace MyNamespace
         {{
             var substitute = NSubstitute.Substitute.For<Foo>();
             {method}(substitute.Bar, new Exception());
+            {method}(value: substitute.Bar, ex: new Exception());
+            {method}(ex: new Exception(), value: substitute.Bar);
         }}
     }}
 }}";
@@ -428,6 +457,8 @@ namespace MyNamespace
         {{
             var substitute = NSubstitute.Substitute.For<Foo>();
             {method}([|substitute.Bar|], new Exception());
+            {method}(value: [|substitute.Bar|], ex: new Exception());
+            {method}(ex: new Exception(), value: [|substitute.Bar|]);
         }}
     }}
 }}";
@@ -454,6 +485,8 @@ namespace MyNamespace
         {{
             var substitute = NSubstitute.Substitute.For<Foo>();
             {method}(substitute[1], new Exception());
+            {method}(value: substitute[1], ex: new Exception());
+            {method}(ex: new Exception(), value: substitute[1]);
         }}
     }}
 }}";
@@ -479,6 +512,8 @@ namespace MyNamespace
         {{
             var substitute = NSubstitute.Substitute.For<Foo>();
             {method}([|substitute[1]|], new Exception());
+            {method}(value: [|substitute[1]|], ex: new Exception());
+            {method}(ex: new Exception(), value: [|substitute[1]|]);
         }}
     }}
 }}";
@@ -519,6 +554,8 @@ namespace NSubstitute
         {{
             Foo substitute = null;
             {method}(substitute.Bar(), new Exception());
+            {method}(value: substitute.Bar(), ex: new Exception());
+            {method}(ex: new Exception(), value: substitute.Bar());
         }}
     }}
 }}";
@@ -982,6 +1019,8 @@ namespace MyNamespace
         {{
             var substitute = NSubstitute.Substitute.For<Foo>();
             var x = {method}([|substitute{call}|], new Exception());
+            var y = {method}(value: [|substitute{call}|], ex: new Exception());
+            var z = {method}(ex: new Exception(), value: [|substitute{call}|]);
         }}
     }}
 }}";
@@ -1022,6 +1061,8 @@ namespace MyNamespace
         {{
             var substitute = NSubstitute.Substitute.For<Foo>();
             var x = {method}(substitute{call}, new Exception());
+            var y = {method}(value: substitute{call}, ex: new Exception());
+            var z = {method}(ex: new Exception(), value: substitute{call});
         }}
     }}
 }}";
@@ -1060,6 +1101,8 @@ namespace MyNamespace
         {{
             var substitute = NSubstitute.Substitute.For<Foo>();
             var x = {method}([|substitute{call}|], new Exception());
+            var y = {method}(value: [|substitute{call}|], ex: new Exception());
+            var z = {method}(ex: new Exception(), value: [|substitute{call}|]);
         }}
     }}
 }}";
@@ -1096,6 +1139,8 @@ namespace MyNamespace
         {{
             var substitute = NSubstitute.Substitute.For<Foo>();
             var x = {method}(substitute{call}, new Exception());
+            var y = {method}(value: substitute{call}, ex: new Exception());
+            var z = {method}(ex: new Exception(), value: substitute{call});
         }}
     }}
 }}";

--- a/tests/NSubstitute.Analyzers.Tests.CSharp/DiagnosticAnalyzerTests/NonSubstitutableMemberReceivedAnalyzerTests/ReceivedAsOrdinaryMethodTests.cs
+++ b/tests/NSubstitute.Analyzers.Tests.CSharp/DiagnosticAnalyzerTests/NonSubstitutableMemberReceivedAnalyzerTests/ReceivedAsOrdinaryMethodTests.cs
@@ -5,17 +5,32 @@ namespace NSubstitute.Analyzers.Tests.CSharp.DiagnosticAnalyzerTests.NonSubstitu
 
 [CombinatoryData(
     "ReceivedExtensions.Received(substitute, Quantity.None())",
+    "ReceivedExtensions.Received(substitute: substitute, requiredQuantity: Quantity.None())",
+    "ReceivedExtensions.Received(requiredQuantity: Quantity.None(), substitute: substitute)",
     "ReceivedExtensions.Received<Foo>(substitute, Quantity.None())",
+    "ReceivedExtensions.Received<Foo>(substitute: substitute, requiredQuantity: Quantity.None())",
+    "ReceivedExtensions.Received<Foo>(requiredQuantity: Quantity.None(), substitute: substitute)",
     "SubstituteExtensions.Received(substitute)",
+    "SubstituteExtensions.Received(substitute: substitute)",
     "SubstituteExtensions.Received<Foo>(substitute)",
+    "SubstituteExtensions.Received<Foo>(substitute: substitute)",
     "ReceivedExtensions.ReceivedWithAnyArgs(substitute, Quantity.None())",
-    "ReceivedExtensions.ReceivedWithAnyArgs<Foo>(substitute, Quantity.None())",
+    "ReceivedExtensions.ReceivedWithAnyArgs(substitute: substitute, requiredQuantity: Quantity.None())",
+    "ReceivedExtensions.ReceivedWithAnyArgs(requiredQuantity: Quantity.None(), substitute: substitute)",
+    "ReceivedExtensions.ReceivedWithAnyArgs<Foo>(substitute: substitute, requiredQuantity: Quantity.None())",
+    "ReceivedExtensions.ReceivedWithAnyArgs<Foo>(requiredQuantity: Quantity.None(), substitute: substitute)",
     "SubstituteExtensions.ReceivedWithAnyArgs(substitute)",
+    "SubstituteExtensions.ReceivedWithAnyArgs(substitute: substitute)",
     "SubstituteExtensions.ReceivedWithAnyArgs<Foo>(substitute)",
+    "SubstituteExtensions.ReceivedWithAnyArgs<Foo>(substitute: substitute)",
     "SubstituteExtensions.DidNotReceive(substitute)",
+    "SubstituteExtensions.DidNotReceive(substitute: substitute)",
     "SubstituteExtensions.DidNotReceive<Foo>(substitute)",
+    "SubstituteExtensions.DidNotReceive<Foo>(substitute: substitute)",
     "SubstituteExtensions.DidNotReceiveWithAnyArgs(substitute)",
-    "SubstituteExtensions.DidNotReceiveWithAnyArgs<Foo>(substitute)")]
+    "SubstituteExtensions.DidNotReceiveWithAnyArgs(substitute: substitute)",
+    "SubstituteExtensions.DidNotReceiveWithAnyArgs<Foo>(substitute)",
+    "SubstituteExtensions.DidNotReceiveWithAnyArgs<Foo>(substitute: substitute)")]
 public class ReceivedAsOrdinaryMethodTests : NonSubstitutableMemberReceivedDiagnosticVerifier
 {
     public override async Task ReportsDiagnostics_WhenCheckingReceivedCallsForNonVirtualMethod(string method)
@@ -107,17 +122,33 @@ namespace MyNamespace
 
     [CombinatoryData(
         "ReceivedExtensions.Received(substitute, Quantity.None())",
+        "ReceivedExtensions.Received(substitute: substitute, requiredQuantity: Quantity.None())",
+        "ReceivedExtensions.Received(requiredQuantity: Quantity.None(), substitute: substitute)",
         "ReceivedExtensions.Received<Func<Foo>>(substitute, Quantity.None())",
+        "ReceivedExtensions.Received<Func<Foo>>(substitute: substitute, requiredQuantity: Quantity.None())",
+        "ReceivedExtensions.Received<Func<Foo>>(requiredQuantity: Quantity.None(), substitute: substitute)",
         "SubstituteExtensions.Received(substitute)",
+        "SubstituteExtensions.Received(substitute: substitute)",
         "SubstituteExtensions.Received<Func<Foo>>(substitute)",
+        "SubstituteExtensions.Received<Func<Foo>>(substitute: substitute)",
         "ReceivedExtensions.ReceivedWithAnyArgs(substitute, Quantity.None())",
+        "ReceivedExtensions.ReceivedWithAnyArgs(substitute: substitute, requiredQuantity: Quantity.None())",
+        "ReceivedExtensions.ReceivedWithAnyArgs(requiredQuantity: Quantity.None(), substitute: substitute)",
         "ReceivedExtensions.ReceivedWithAnyArgs<Func<Foo>>(substitute, Quantity.None())",
+        "ReceivedExtensions.ReceivedWithAnyArgs<Func<Foo>>(substitute: substitute, requiredQuantity: Quantity.None())",
+        "ReceivedExtensions.ReceivedWithAnyArgs<Func<Foo>>(requiredQuantity: Quantity.None(), substitute: substitute)",
         "SubstituteExtensions.ReceivedWithAnyArgs(substitute)",
+        "SubstituteExtensions.ReceivedWithAnyArgs(substitute: substitute)",
         "SubstituteExtensions.ReceivedWithAnyArgs<Func<Foo>>(substitute)",
+        "SubstituteExtensions.ReceivedWithAnyArgs<Func<Foo>>(substitute: substitute)",
         "SubstituteExtensions.DidNotReceive(substitute)",
+        "SubstituteExtensions.DidNotReceive(substitute: substitute)",
         "SubstituteExtensions.DidNotReceive<Func<Foo>>(substitute)",
+        "SubstituteExtensions.DidNotReceive<Func<Foo>>(substitute: substitute)",
         "SubstituteExtensions.DidNotReceiveWithAnyArgs(substitute)",
-        "SubstituteExtensions.DidNotReceiveWithAnyArgs<Func<Foo>>(substitute)")]
+        "SubstituteExtensions.DidNotReceiveWithAnyArgs(substitute: substitute)",
+        "SubstituteExtensions.DidNotReceiveWithAnyArgs<Func<Foo>>(substitute)",
+        "SubstituteExtensions.DidNotReceiveWithAnyArgs<Func<Foo>>(substitute: substitute)")]
     public override async Task ReportsNoDiagnostics_WhenCheckingReceivedCallsForDelegate(string method)
     {
         var source = $@"using NSubstitute;
@@ -250,17 +281,31 @@ namespace MyNamespace
 
     [CombinatoryData(
         "ReceivedExtensions.Received(substitute, Quantity.None())",
+        "ReceivedExtensions.Received(substitute: substitute, requiredQuantity: Quantity.None())",
+        "ReceivedExtensions.Received(requiredQuantity: Quantity.None(), substitute: substitute)",
         "ReceivedExtensions.Received<Foo<int>>(substitute, Quantity.None())",
+        "ReceivedExtensions.Received<Foo<int>>(substitute: substitute, requiredQuantity: Quantity.None())",
+        "ReceivedExtensions.Received<Foo<int>>(requiredQuantity: Quantity.None(), substitute: substitute)",
         "SubstituteExtensions.Received(substitute)",
+        "SubstituteExtensions.Received(substitute: substitute)",
         "SubstituteExtensions.Received<Foo<int>>(substitute)",
+        "SubstituteExtensions.Received<Foo<int>>(substitute: substitute)",
         "ReceivedExtensions.ReceivedWithAnyArgs(substitute, Quantity.None())",
-        "ReceivedExtensions.ReceivedWithAnyArgs<Foo<int>>(substitute, Quantity.None())",
+        "ReceivedExtensions.ReceivedWithAnyArgs(substitute: substitute, requiredQuantity: Quantity.None())",
+        "ReceivedExtensions.ReceivedWithAnyArgs(requiredQuantity: Quantity.None(), substitute: substitute)",
+        "ReceivedExtensions.ReceivedWithAnyArgs<Foo<int>>(substitute: substitute, requiredQuantity: Quantity.None())",
+        "ReceivedExtensions.ReceivedWithAnyArgs<Foo<int>>(requiredQuantity: Quantity.None(), substitute: substitute)",
         "SubstituteExtensions.ReceivedWithAnyArgs(substitute)",
+        "SubstituteExtensions.ReceivedWithAnyArgs(substitute: substitute)",
         "SubstituteExtensions.ReceivedWithAnyArgs<Foo<int>>(substitute)",
+        "SubstituteExtensions.ReceivedWithAnyArgs<Foo<int>>(substitute: substitute)",
         "SubstituteExtensions.DidNotReceive(substitute)",
+        "SubstituteExtensions.DidNotReceive(substitute: substitute)",
         "SubstituteExtensions.DidNotReceive<Foo<int>>(substitute)",
+        "SubstituteExtensions.DidNotReceive<Foo<int>>(substitute: substitute)",
         "SubstituteExtensions.DidNotReceiveWithAnyArgs(substitute)",
-        "SubstituteExtensions.DidNotReceiveWithAnyArgs<Foo<int>>(substitute)")]
+        "SubstituteExtensions.DidNotReceiveWithAnyArgs(substitute: substitute)",
+        "SubstituteExtensions.DidNotReceiveWithAnyArgs<Foo<int>>(substitute: substitute)")]
     public override async Task ReportsNoDiagnostics_WhenCheckingReceivedCallsForGenericInterfaceMethod(string method)
     {
         var source = $@"using NSubstitute;

--- a/tests/NSubstitute.Analyzers.Tests.CSharp/DiagnosticAnalyzerTests/NonSubstitutableMemberWhenAnalyzerTests/NonSubstitutableMemberWhenDiagnosticVerifier.cs
+++ b/tests/NSubstitute.Analyzers.Tests.CSharp/DiagnosticAnalyzerTests/NonSubstitutableMemberWhenAnalyzerTests/NonSubstitutableMemberWhenDiagnosticVerifier.cs
@@ -21,7 +21,6 @@ public abstract class NonSubstitutableMemberWhenDiagnosticVerifier : CSharpDiagn
     [CombinatoryTheory]
     [InlineData("sub => [|sub.Bar(Arg.Any<int>())|]")]
     [InlineData("delegate(Foo sub) { [|sub.Bar(Arg.Any<int>())|]; }")]
-    [InlineData("sub => { [|sub.Bar(Arg.Any<int>())|]; }")]
     public abstract Task ReportsDiagnostics_WhenSettingValueForNonVirtualMethod(string method, string whenAction);
 
     [CombinatoryTheory]

--- a/tests/NSubstitute.Analyzers.Tests.CSharp/DiagnosticAnalyzerTests/NonSubstitutableMemberWhenAnalyzerTests/WhenAsOrdinaryMethodTests.cs
+++ b/tests/NSubstitute.Analyzers.Tests.CSharp/DiagnosticAnalyzerTests/NonSubstitutableMemberWhenAnalyzerTests/WhenAsOrdinaryMethodTests.cs
@@ -27,6 +27,8 @@ namespace MyNamespace
             int i = 1;
             var substitute = NSubstitute.Substitute.For<Foo>();
             {method}(substitute, {whenAction}).Do(callInfo => i++);
+            {method}(substitute: substitute, substituteCall: {whenAction}).Do(callInfo => i++);
+            {method}(substituteCall: {whenAction}, substitute: substitute).Do(callInfo => i++);
         }}
     }}
 }}";
@@ -59,6 +61,8 @@ namespace MyNamespace
             var substitute = Substitute.For<Foo>();
 
             {method}(substitute, {whenAction}).Do(callInfo => i++);
+            {method}(substitute: substitute, substituteCall: {whenAction}).Do(callInfo => i++);
+            {method}(substituteCall: {whenAction}, substitute: substitute).Do(callInfo => i++);
         }}
     }}
 }}";
@@ -86,6 +90,8 @@ namespace MyNamespace
             int i = 1;
             var substitute = NSubstitute.Substitute.For<Foo>();
             {method}(substitute, {whenAction}).Do(callInfo => i++);
+            {method}(substitute: substitute, substituteCall: {whenAction}).Do(callInfo => i++);
+            {method}(substituteCall: {whenAction}, substitute: substitute).Do(callInfo => i++);
         }}
     }}
 }}";
@@ -118,6 +124,8 @@ namespace MyNamespace
             int i = 1;
             var substitute = NSubstitute.Substitute.For<Foo>();
             {method}(substitute, {whenAction}).Do(callInfo => i++);
+            {method}(substitute: substitute, substituteCall: {whenAction}).Do(callInfo => i++);
+            {method}(substituteCall: {whenAction}, substitute: substitute).Do(callInfo => i++);
         }}
     }}
 }}";
@@ -139,6 +147,8 @@ namespace MyNamespace
             int i = 1;
             var substitute = Substitute.For<Func<int>>();
             {method}(substitute, {whenAction}).Do(callInfo => i++);
+            {method}(substitute: substitute, substituteCall: {whenAction}).Do(callInfo => i++);
+            {method}(substituteCall: {whenAction}, substitute: substitute).Do(callInfo => i++);
         }}
     }}
 }}";
@@ -171,7 +181,8 @@ namespace MyNamespace
             int i = 1;
             var substitute = NSubstitute.Substitute.For<Foo>();
             {method}(substitute, {whenAction}).Do(callInfo => i++);
-
+            {method}(substitute: substitute, substituteCall: {whenAction}).Do(callInfo => i++);
+            {method}(substituteCall: {whenAction}, substitute: substitute).Do(callInfo => i++);
         }}
     }}
 }}";
@@ -197,6 +208,8 @@ namespace MyNamespace
             int i = 1;
             var substitute = NSubstitute.Substitute.For<Foo>();
             {method}(substitute, {whenAction}).Do(callInfo => i++);
+            {method}(substitute: substitute, substituteCall: {whenAction}).Do(callInfo => i++);
+            {method}(substituteCall: {whenAction}, substitute: substitute).Do(callInfo => i++);
         }}
     }}
 }}";
@@ -222,6 +235,8 @@ namespace MyNamespace
             int i = 1;
             var substitute = NSubstitute.Substitute.For<Foo>();
             {method}(substitute, {whenAction}).Do(callInfo => i++);
+            {method}(substitute: substitute, substituteCall: {whenAction}).Do(callInfo => i++);
+            {method}(substituteCall: {whenAction}, substitute: substitute).Do(callInfo => i++);
         }}
     }}
 }}";
@@ -246,6 +261,8 @@ namespace MyNamespace
             int i = 1;
             var substitute = NSubstitute.Substitute.For<Foo>();
             {method}(substitute, {whenAction}).Do(callInfo => i++);
+            {method}(substitute: substitute, substituteCall: {whenAction}).Do(callInfo => i++);
+            {method}(substituteCall: {whenAction}, substitute: substitute).Do(callInfo => i++);
         }}
     }}
 }}";
@@ -271,6 +288,8 @@ namespace MyNamespace
             int i = 1;
             var substitute = NSubstitute.Substitute.For<Foo<int>>();
             {method}(substitute, {whenAction}).Do(callInfo => i++);
+            {method}(substitute: substitute, substituteCall: {whenAction}).Do(callInfo => i++);
+            {method}(substituteCall: {whenAction}, substitute: substitute).Do(callInfo => i++);
         }}
     }}
 }}";
@@ -295,6 +314,8 @@ namespace MyNamespace
             int i = 1;
             var substitute = NSubstitute.Substitute.For<Foo>();
             {method}(substitute, {whenAction}).Do(callInfo => i++);
+            {method}(substitute: substitute, substituteCall: {whenAction}).Do(callInfo => i++);
+            {method}(substituteCall: {whenAction}, substitute: substitute).Do(callInfo => i++);
         }}
     }}
 }}";
@@ -320,6 +341,8 @@ namespace MyNamespace
             int i = 1;
             var substitute = NSubstitute.Substitute.For<Foo>();
             {method}(substitute, {whenAction}).Do(callInfo => i++);
+            {method}(substitute: substitute, substituteCall: {whenAction}).Do(callInfo => i++);
+            {method}(substituteCall: {whenAction}, substitute: substitute).Do(callInfo => i++);
         }}
     }}
 }}";
@@ -383,6 +406,8 @@ namespace MyNamespace
             int i = 1;
             var substitute = NSubstitute.Substitute.For<Foo>();
             {method}(substitute, {whenAction}).Do(callInfo => i++);
+            {method}(substitute: substitute, substituteCall: {whenAction}).Do(callInfo => i++);
+            {method}(substituteCall: {whenAction}, substitute: substitute).Do(callInfo => i++);
         }}
     }}
 }}";
@@ -408,6 +433,8 @@ namespace MyNamespace
             int i = 1;
             var substitute = NSubstitute.Substitute.For<Foo>();
             {method}(substitute, {whenAction}).Do(callInfo => i++);
+            {method}(substitute: substitute, substituteCall: {whenAction}).Do(callInfo => i++);
+            {method}(substituteCall: {whenAction}, substitute: substitute).Do(callInfo => i++);
         }}
     }}
 }}";
@@ -433,6 +460,8 @@ namespace MyNamespace
             int i = 1;
             var substitute = NSubstitute.Substitute.For<Foo>();
             {method}(substitute, {whenAction}).Do(callInfo => i++);
+            {method}(substitute: substitute, substituteCall: {whenAction}).Do(callInfo => i++);
+            {method}(substituteCall: {whenAction}, substitute: substitute).Do(callInfo => i++);
         }}
     }}
 }}";
@@ -467,7 +496,21 @@ namespace MyNamespace
                 return Task.CompletedTask;
             }}
 
+            Task OtherSubstituteCall(Foo sub)
+            {{
+                [|sub.Bar(Arg.Any<int>())|];
+                return Task.CompletedTask;
+            }}
+
+            Task YetAnotherSubstituteCall(Foo sub)
+            {{
+                [|sub.Bar(Arg.Any<int>())|];
+                return Task.CompletedTask;
+            }}
+
             {method}(substitute, SubstituteCall).Do(callInfo => i++);
+            {method}(substitute: substitute, substituteCall: OtherSubstituteCall).Do(callInfo => i++);
+            {method}(substituteCall: YetAnotherSubstituteCall, substitute: substitute).Do(callInfo => i++);
             substitute.Bar(1);
         }}
     }}
@@ -497,8 +540,12 @@ namespace MyNamespace
             var substitute = NSubstitute.Substitute.For<Foo>();
 
             Task SubstituteCall(Foo sub) => Task.FromResult([|sub.Bar(Arg.Any<int>())|]);
+            Task OtherSubstituteCall(Foo sub) => Task.FromResult([|sub.Bar(Arg.Any<int>())|]);
+            Task YetAnotherSubstituteCall(Foo sub) => Task.FromResult([|sub.Bar(Arg.Any<int>())|]);
 
             {method}(substitute, SubstituteCall).Do(callInfo => i++);
+            {method}(substitute: substitute, substituteCall: OtherSubstituteCall).Do(callInfo => i++);
+            {method}(substituteCall: YetAnotherSubstituteCall, substitute: substitute).Do(callInfo => i++);
             substitute.Bar(1);
         }}
     }}
@@ -529,10 +576,24 @@ namespace MyNamespace
             var substitute = NSubstitute.Substitute.For<Foo>();
 
             {method}(substitute, SubstituteCall).Do(callInfo => i++);
+            {method}(substitute: substitute, substituteCall: OtherSubstituteCall).Do(callInfo => i++);
+            {method}(substituteCall: YetAnotherSubstituteCall, substitute: substitute).Do(callInfo => i++);
             substitute.Bar(1);
         }}
 
         private Task SubstituteCall(Foo sub)
+        {{
+            var objBarr = [|sub.Bar(Arg.Any<int>())|];
+            return Task.CompletedTask;
+        }}
+
+        private Task OtherSubstituteCall(Foo sub)
+        {{
+            var objBarr = [|sub.Bar(Arg.Any<int>())|];
+            return Task.CompletedTask;
+        }}
+
+        private Task YetAnotherSubstituteCall(Foo sub)
         {{
             var objBarr = [|sub.Bar(Arg.Any<int>())|];
             return Task.CompletedTask;
@@ -564,10 +625,16 @@ namespace MyNamespace
             var substitute = NSubstitute.Substitute.For<Foo>();
 
             {method}(substitute, SubstituteCall).Do(callInfo => i++);
+            {method}(substitute: substitute, substituteCall: OtherSubstituteCall).Do(callInfo => i++);
+            {method}(substituteCall: YetAnotherSubstituteCall, substitute: substitute).Do(callInfo => i++);
             substitute.Bar(1);
         }}
 
         private Task SubstituteCall(Foo sub) => Task.FromResult([|sub.Bar(Arg.Any<int>())|]);
+
+        private Task OtherSubstituteCall(Foo sub) => Task.FromResult([|sub.Bar(Arg.Any<int>())|]);
+
+        private Task YetAnotherSubstituteCall(Foo sub) => Task.FromResult([|sub.Bar(Arg.Any<int>())|]);
     }}
 }}";
         await VerifyDiagnostic(source, NonVirtualWhenSetupSpecificationDescriptor, "Member Bar can not be intercepted. Only interface members and virtual, overriding, and abstract members can be intercepted.");
@@ -601,6 +668,8 @@ namespace MyNamespace
             }}
 
             {method}(substitute, SubstituteCall).Do(callInfo => i++);
+            {method}(substitute: substitute, substituteCall: SubstituteCall).Do(callInfo => i++);
+            {method}(substituteCall: SubstituteCall, substitute: substitute).Do(callInfo => i++);
             substitute.Bar(1);
         }}
     }}
@@ -633,6 +702,8 @@ namespace MyNamespace
             Task SubstituteCall(Foo sub) => Task.FromResult(sub.Bar(Arg.Any<int>()));
 
             {method}(substitute, SubstituteCall).Do(callInfo => i++);
+            {method}(substitute: substitute, substituteCall: SubstituteCall).Do(callInfo => i++);
+            {method}(substituteCall: SubstituteCall, substitute: substitute).Do(callInfo => i++);
             substitute.Bar(1);
         }}
     }}
@@ -662,6 +733,8 @@ namespace MyNamespace
             var substitute = NSubstitute.Substitute.For<Foo>();
 
             {method}(substitute, SubstituteCall).Do(callInfo => i++);
+            {method}(substitute: substitute, substituteCall: SubstituteCall).Do(callInfo => i++);
+            {method}(substituteCall: SubstituteCall, substitute: substitute).Do(callInfo => i++);
             substitute.Bar(1);
         }}
 
@@ -697,6 +770,8 @@ namespace MyNamespace
             var substitute = NSubstitute.Substitute.For<Foo>();
 
             {method}(substitute, SubstituteCall).Do(callInfo => i++);
+            {method}(substitute: substitute, substituteCall: SubstituteCall).Do(callInfo => i++);
+            {method}(substituteCall: SubstituteCall, substitute: substitute).Do(callInfo => i++);
             substitute.Bar(1);
         }}
 
@@ -734,6 +809,8 @@ namespace MyNamespace
             int i = 0;
             var substitute = NSubstitute.Substitute.For<Foo>();
             {method}(substitute, {call}).Do(callInfo => i++);
+            {method}(substitute: substitute, substituteCall: {call}).Do(callInfo => i++);
+            {method}(substituteCall: {call}, substitute: substitute).Do(callInfo => i++);
         }}
     }}
 }}";
@@ -773,6 +850,8 @@ namespace MyNamespace
             int i = 0;
             var substitute = NSubstitute.Substitute.For<Foo>();
             {method}(substitute, {call}).Do(callInfo => i++);
+            {method}(substitute: substitute, substituteCall: {call}).Do(callInfo => i++);
+            {method}(substituteCall: {call}, substitute: substitute).Do(callInfo => i++);
         }}
     }}
 }}";
@@ -810,6 +889,8 @@ namespace MyNamespace
             int i = 0;
             var substitute = NSubstitute.Substitute.For<Foo>();
             {method}(substitute, {call}).Do(callInfo => i++);
+            {method}(substitute: substitute, substituteCall: {call}).Do(callInfo => i++);
+            {method}(substituteCall: {call}, substitute: substitute).Do(callInfo => i++);
         }}
     }}
 }}";
@@ -844,7 +925,8 @@ namespace MyNamespace
         {{
             int i = 0;
             var substitute = NSubstitute.Substitute.For<Foo>();
-            {method}(substitute, {call}).Do(callInfo => i++);
+            {method}(substitute: substitute, substituteCall: {call}).Do(callInfo => i++);
+            {method}(substituteCall: {call}, substitute: substitute).Do(callInfo => i++);
         }}
     }}
 }}";

--- a/tests/NSubstitute.Analyzers.Tests.VisualBasic/DiagnosticAnalyzersTests/CallInfoAnalyzerTests/AndDoesMethodPrecededByOrdinaryMethodTests.cs
+++ b/tests/NSubstitute.Analyzers.Tests.VisualBasic/DiagnosticAnalyzersTests/CallInfoAnalyzerTests/AndDoesMethodPrecededByOrdinaryMethodTests.cs
@@ -24,7 +24,16 @@ Namespace MyNamespace
         Public Sub Test()
             Dim substitute = NSubstitute.Substitute.[For](Of Foo)()
             Dim returnedValue = SubstituteExtensions.Returns({call}, 1)
+            Dim otherValue  = SubstituteExtensions.Returns(value:= {call}, returnThis:= 1)
+            Dim yetAnotherValue  = SubstituteExtensions.Returns(returnThis:= 1, value:= {call})
+
             returnedValue.{method}(Function(callInfo)
+                                      {argAccess}
+                                  End Function)
+            otherValue.{method}(Function(callInfo)
+                                      {argAccess}
+                                  End Function)
+            yetAnotherValue.{method}(Function(callInfo)
                                       {argAccess}
                                   End Function)
         End Sub
@@ -52,6 +61,12 @@ Namespace MyNamespace
             SubstituteExtensions.Returns({call}, 1).{method}(Function(callInfo)
                                {argAccess}
                            End Function)
+            SubstituteExtensions.Returns(value:= {call}, returnThis:= 1).{method}(Function(callInfo)
+                               {argAccess}
+                           End Function)
+            SubstituteExtensions.Returns(returnThis:= 1, value:= {call}).{method}(Function(callInfo)
+                               {argAccess}
+                           End Function)
         End Sub
     End Class
 End Namespace
@@ -77,6 +92,12 @@ Namespace MyNamespace
             SubstituteExtensions.Returns({call}, 1).{method}(Function(callInfo)
                                    {argAccess}
                            End Function)
+            SubstituteExtensions.Returns(value:= {call}, returnThis:= 1).{method}(Function(callInfo)
+                                   {argAccess}
+                           End Function)
+            SubstituteExtensions.Returns(returnThis:= 1, value:= {call}).{method}(Function(callInfo)
+                                   {argAccess}
+                           End Function)
         End Sub
     End Class
 End Namespace";
@@ -99,6 +120,12 @@ Namespace MyNamespace
         Public Sub Test()
             Dim substitute = NSubstitute.Substitute.[For](Of Foo)()
             SubstituteExtensions.Returns({call}, 1).{method}(Function(callInfo)
+                                   {argAccess}
+                           End Function)
+            SubstituteExtensions.Returns(value:= {call}, returnThis:= 1).{method}(Function(callInfo)
+                                   {argAccess}
+                           End Function)
+            SubstituteExtensions.Returns(returnThis:= 1, value:= {call}).{method}(Function(callInfo)
                                    {argAccess}
                            End Function)
         End Sub
@@ -212,6 +239,12 @@ Namespace MyNamespace
             SubstituteExtensions.Returns({call}, 1).{method}(Function(callInfo)
                                    {argAccess}
                            End Function)
+            SubstituteExtensions.Returns(value:= {call}, returnThis:= 1).{method}(Function(callInfo)
+                                   {argAccess}
+                           End Function)
+            SubstituteExtensions.Returns(returnThis:= 1, value:= {call}).{method}(Function(callInfo)
+                                   {argAccess}
+                           End Function)
         End Sub
     End Class
 End Namespace";
@@ -245,6 +278,12 @@ Namespace MyNamespace
             SubstituteExtensions.Returns({call}, 1).{method}(Function(callInfo)
                                {argAccess}
                            End Function)
+            SubstituteExtensions.Returns(value:= {call}, returnThis:= 1).{method}(Function(callInfo)
+                               {argAccess}
+                           End Function)
+            SubstituteExtensions.Returns(returnThis:= 1, value:= {call}).{method}(Function(callInfo)
+                               {argAccess}
+                           End Function)
         End Sub
     End Class
 End Namespace
@@ -275,6 +314,12 @@ Namespace MyNamespace
         Public Sub Test()
             Dim substitute = NSubstitute.Substitute.[For](Of Foo)()
             SubstituteExtensions.Returns({call}, 1).{method}(Function(callInfo)
+                                   {argAccess}
+                           End Function)
+            SubstituteExtensions.Returns(value:= {call}, returnThis:= 1).{method}(Function(callInfo)
+                                   {argAccess}
+                           End Function)
+            SubstituteExtensions.Returns(returnThis:= 1, value:= {call}).{method}(Function(callInfo)
                                    {argAccess}
                            End Function)
         End Sub
@@ -310,6 +355,12 @@ Namespace MyNamespace
             SubstituteExtensions.Returns({call}, 1).{method}(Function(callInfo)
                                {argAccess}
                            End Function)
+            SubstituteExtensions.Returns(value:= {call}, returnThis:= 1).{method}(Function(callInfo)
+                               {argAccess}
+                           End Function)
+            SubstituteExtensions.Returns(returnThis:= 1, value:= {call}).{method}(Function(callInfo)
+                               {argAccess}
+                           End Function)
         End Sub
     End Class
 End Namespace
@@ -335,6 +386,12 @@ Namespace MyNamespace
         Public Sub Test()
             Dim substitute = NSubstitute.Substitute.[For](Of Foo)()
             SubstituteExtensions.Returns({call}, 1).{method}(Function(callInfo)
+                               {argAccess}
+                           End Function)
+            SubstituteExtensions.Returns(value:= {call}, returnThis:= 1).{method}(Function(callInfo)
+                               {argAccess}
+                           End Function)
+            SubstituteExtensions.Returns(returnThis:= 1, value:= {call}).{method}(Function(callInfo)
                                {argAccess}
                            End Function)
         End Sub
@@ -364,6 +421,12 @@ Namespace MyNamespace
             SubstituteExtensions.Returns({call}, 1).{method}(Function(callInfo)
                                {argAccess}
                            End Function)
+            SubstituteExtensions.Returns(value:= {call}, returnThis:= 1).{method}(Function(callInfo)
+                               {argAccess}
+                           End Function)
+            SubstituteExtensions.Returns(returnThis:= 1, value:= {call}).{method}(Function(callInfo)
+                               {argAccess}
+                           End Function)
         End Sub
     End Class
 End Namespace
@@ -388,6 +451,12 @@ Namespace MyNamespace
         Public Sub Test()
             Dim substitute = NSubstitute.Substitute.[For](Of Foo)()
             SubstituteExtensions.Returns({call}, 1).{method}(Function(callInfo)
+                               {argAccess}
+                           End Function)
+            SubstituteExtensions.Returns(value:= {call}, returnThis:= 1).{method}(Function(callInfo)
+                               {argAccess}
+                           End Function)
+            SubstituteExtensions.Returns(returnThis:= 1, value:= {call}).{method}(Function(callInfo)
                                {argAccess}
                            End Function)
         End Sub
@@ -424,6 +493,12 @@ Namespace MyNamespace
         Public Sub Test()
             Dim substitute = NSubstitute.Substitute.[For](Of IFoo)()
             SubstituteExtensions.Returns({call}, 1).{method}(Function(callInfo)
+                               {argAccess}
+                           End Function)
+            SubstituteExtensions.Returns(value:= {call}, returnThis:= 1).{method}(Function(callInfo)
+                               {argAccess}
+                           End Function)
+            SubstituteExtensions.Returns(returnThis:= 1, value:= {call}).{method}(Function(callInfo)
                                {argAccess}
                            End Function)
         End Sub
@@ -486,6 +561,12 @@ Namespace MyNamespace
             SubstituteExtensions.Returns({call}, 1).{method}(Function(callInfo)
                                {argAccess}
                            End Function)
+            SubstituteExtensions.Returns(value:= {call}, returnThis:= 1).{method}(Function(callInfo)
+                               {argAccess}
+                           End Function)
+            SubstituteExtensions.Returns(returnThis:= 1, value:= {call}).{method}(Function(callInfo)
+                               {argAccess}
+                           End Function)
         End Sub
     End Class
 End Namespace
@@ -514,6 +595,12 @@ Namespace MyNamespace
             SubstituteExtensions.Returns({call}, 1).{method}(Function(callInfo)
                                {argAccess}
                            End Function)
+            SubstituteExtensions.Returns(value:= {call}, returnThis:= 1).{method}(Function(callInfo)
+                               {argAccess}
+                           End Function)
+            SubstituteExtensions.Returns(returnThis:= 1, value:= {call}).{method}(Function(callInfo)
+                               {argAccess}
+                           End Function)
         End Sub
     End Class
 End Namespace
@@ -538,6 +625,12 @@ Namespace MyNamespace
             SubstituteExtensions.Returns({call}, 1).{method}(Function(callInfo)
                                [|callInfo(1)|] = 1
                            End Function)
+            SubstituteExtensions.Returns(value:= {call}, returnThis:= 1).{method}(Function(callInfo)
+                               [|callInfo(1)|] = 1
+                           End Function)
+            SubstituteExtensions.Returns(returnThis:= 1, value:= {call}).{method}(Function(callInfo)
+                               [|callInfo(1)|] = 1
+                           End Function)
         End Sub
     End Class
 End Namespace
@@ -559,6 +652,12 @@ Namespace MyNamespace
             Dim value As Integer = 0
             Dim substitute = NSubstitute.Substitute.[For](Of Foo)()
             SubstituteExtensions.Returns(substitute.Bar(value), 1).{method}(Function(callInfo)
+                                              callInfo(0) = 1
+                                          End Function)
+            SubstituteExtensions.Returns(value:= substitute.Bar(value), returnThis:= 1).{method}(Function(callInfo)
+                                              callInfo(0) = 1
+                                          End Function)
+            SubstituteExtensions.Returns(returnThis:= 1, value:= substitute.Bar(value)).{method}(Function(callInfo)
                                               callInfo(0) = 1
                                           End Function)
         End Sub
@@ -585,6 +684,12 @@ Namespace MyNamespace
             SubstituteExtensions.Returns(substitute.Bar(value), 1).{method}(Function(callInfo)
                                               callInfo(0) = 1
                                           End Function)
+            SubstituteExtensions.Returns(value:= substitute.Bar(value), returnThis:= 1).{method}(Function(callInfo)
+                                              callInfo(0) = 1
+                                          End Function)
+            SubstituteExtensions.Returns(returnThis:= 1, value:= substitute.Bar(value)).{method}(Function(callInfo)
+                                              callInfo(0) = 1
+                                          End Function)
         End Sub
     End Class
 End Namespace
@@ -607,6 +712,12 @@ Namespace MyNamespace
             Dim value As Integer = 0
             Dim substitute = NSubstitute.Substitute.[For](Of Foo)()
             SubstituteExtensions.Returns(substitute.Bar(value), 1).{method}(Function(callInfo)
+                                              [|callInfo(1)|] = 1
+                                          End Function)
+            SubstituteExtensions.Returns(value:= substitute.Bar(value), returnThis:= 1).{method}(Function(callInfo)
+                                              [|callInfo(1)|] = 1
+                                          End Function)
+            SubstituteExtensions.Returns(returnThis:= 1, value:= substitute.Bar(value)).{method}(Function(callInfo)
                                               [|callInfo(1)|] = 1
                                           End Function)
         End Sub
@@ -634,6 +745,12 @@ Namespace MyNamespace
             SubstituteExtensions.Returns(substitute.Bar(value), 1).{method}(Function(callInfo)
                                               [|callInfo(0)|] = {right}
                                           End Function)
+            SubstituteExtensions.Returns(value:= substitute.Bar(value), returnThis:= 1).{method}(Function(callInfo)
+                                              [|callInfo(0)|] = {right}
+                                          End Function)
+            SubstituteExtensions.Returns(returnThis:= 1, value:= substitute.Bar(value)).{method}(Function(callInfo)
+                                              [|callInfo(0)|] = {right}
+                                          End Function)
         End Sub
     End Class
 End Namespace
@@ -658,6 +775,12 @@ Namespace MyNamespace
             Dim value As {left} = Nothing
             Dim substitute = NSubstitute.Substitute.[For](Of Foo)()
             SubstituteExtensions.Returns(substitute.Bar(value), 1).{method}(Function(callInfo)
+                                              callInfo(0) = {right}
+                                          End Function)
+            SubstituteExtensions.Returns(value:= substitute.Bar(value), returnThis:= 1).{method}(Function(callInfo)
+                                              callInfo(0) = {right}
+                                          End Function)
+            SubstituteExtensions.Returns(returnThis:= 1, value:= substitute.Bar(value)).{method}(Function(callInfo)
                                               callInfo(0) = {right}
                                           End Function)
         End Sub

--- a/tests/NSubstitute.Analyzers.Tests.VisualBasic/DiagnosticAnalyzersTests/CallInfoAnalyzerTests/DoMethodPrecededByOrdinaryMethodTests.cs
+++ b/tests/NSubstitute.Analyzers.Tests.VisualBasic/DiagnosticAnalyzersTests/CallInfoAnalyzerTests/DoMethodPrecededByOrdinaryMethodTests.cs
@@ -26,8 +26,20 @@ Namespace MyNamespace
             Dim returnValue = {method}(mock, Function(substitute) 
                                                 Dim x = {call}
                                            End Function)
+            Dim otherValue = {method}(substitute:= mock, substituteCall:= Function(substitute) 
+                                                Dim x = {call}
+                                           End Function)
+            Dim yetAnotherValue = {method}(substituteCall:= Function(substitute) 
+                                                Dim x = {call}
+                                           End Function, substitute:= mock)
 
             returnValue.Do(Function(callInfo)
+                                {argAccess}
+                           End Function)
+            otherValue.Do(Function(callInfo)
+                                {argAccess}
+                           End Function)
+            yetAnotherValue.Do(Function(callInfo)
                                 {argAccess}
                            End Function)
         End Sub
@@ -57,6 +69,16 @@ Namespace MyNamespace
                           End Function).Do(Function(callInfo)
                                                {argAccess}
                                            End Function)
+            {method}(substitute:= mock, substituteCall:= Function(substitute) 
+                             Dim x = {call}
+                          End Function).Do(Function(callInfo)
+                                               {argAccess}
+                                           End Function)
+            {method}(substituteCall:= Function(substitute) 
+                             Dim x = {call}
+                          End Function, substitute:= mock).Do(Function(callInfo)
+                                               {argAccess}
+                                           End Function)
         End Sub
     End Class
 End Namespace
@@ -84,6 +106,16 @@ Namespace MyNamespace
                           End Function).Do(Function(callInfo)
                                                {argAccess}
                                            End Function)
+            {method}(substitute:= mock, substituteCall:= Function(substitute) 
+                             Dim x = {call}
+                          End Function).Do(Function(callInfo)
+                                               {argAccess}
+                                           End Function)
+            {method}(substituteCall:= Function(substitute) 
+                             Dim x = {call}
+                          End Function, substitute:= mock).Do(Function(callInfo)
+                                               {argAccess}
+                                           End Function)
         End Sub
     End Class
 End Namespace";
@@ -108,6 +140,16 @@ Namespace MyNamespace
             {method}(mock, Function(substitute) 
                              Dim x = {call}
                           End Function).Do(Function(callInfo)
+                                               {argAccess}
+                                           End Function)
+            {method}(substitute:= mock, substituteCall:= Function(substitute) 
+                             Dim x = {call}
+                          End Function).Do(Function(callInfo)
+                                               {argAccess}
+                                           End Function)
+            {method}(substituteCall:= Function(substitute) 
+                             Dim x = {call}
+                          End Function, substitute:= mock).Do(Function(callInfo)
                                                {argAccess}
                                            End Function)
         End Sub
@@ -225,6 +267,16 @@ Namespace MyNamespace
                           End Function).Do(Function(callInfo)
                                                {argAccess}
                                            End Function)
+            {method}(substitute:= mock, substituteCall:= Function(substitute) 
+                             Dim x = {call}
+                          End Function).Do(Function(callInfo)
+                                               {argAccess}
+                                           End Function)
+            {method}(substituteCall:= Function(substitute) 
+                             Dim x = {call}
+                          End Function, substitute:= mock).Do(Function(callInfo)
+                                               {argAccess}
+                                           End Function)
         End Sub
     End Class
 End Namespace";
@@ -260,6 +312,16 @@ Namespace MyNamespace
                           End Function).Do(Function(callInfo)
                                                {argAccess}
                                            End Function)
+            {method}(substitute:= mock, substituteCall:= Function(substitute) 
+                             Dim x = {call}
+                          End Function).Do(Function(callInfo)
+                                               {argAccess}
+                                           End Function)
+            {method}(substituteCall:= Function(substitute) 
+                             Dim x = {call}
+                          End Function, substitute:= mock).Do(Function(callInfo)
+                                               {argAccess}
+                                           End Function)
         End Sub
     End Class
 End Namespace
@@ -292,6 +354,16 @@ Namespace MyNamespace
             {method}(mock, Function(substitute) 
                              Dim x = {call}
                           End Function).Do(Function(callInfo)
+                                               {argAccess}
+                                           End Function)
+            {method}(substitute:= mock, substituteCall:= Function(substitute) 
+                             Dim x = {call}
+                          End Function).Do(Function(callInfo)
+                                               {argAccess}
+                                           End Function)
+            {method}(substituteCall:= Function(substitute) 
+                             Dim x = {call}
+                          End Function, substitute:= mock).Do(Function(callInfo)
                                                {argAccess}
                                            End Function)
         End Sub
@@ -329,6 +401,16 @@ Namespace MyNamespace
                           End Function).Do(Function(callInfo)
                                                {argAccess}
                                            End Function)
+            {method}(substitute:= mock, substituteCall:= Function(substitute) 
+                             Dim x = {call}
+                          End Function).Do(Function(callInfo)
+                                               {argAccess}
+                                           End Function)
+            {method}(substituteCall:= Function(substitute) 
+                             Dim x = {call}
+                          End Function, substitute:= mock).Do(Function(callInfo)
+                                               {argAccess}
+                                           End Function)
         End Sub
     End Class
 End Namespace
@@ -356,6 +438,16 @@ Namespace MyNamespace
             {method}(mock, Function(substitute) 
                              Dim x = {call}
                           End Function).Do(Function(callInfo)
+                                               {argAccess}
+                                           End Function)
+            {method}(substitute:= mock, substituteCall:= Function(substitute) 
+                             Dim x = {call}
+                          End Function).Do(Function(callInfo)
+                                               {argAccess}
+                                           End Function)
+            {method}(substituteCall:= Function(substitute) 
+                             Dim x = {call}
+                          End Function, substitute:= mock).Do(Function(callInfo)
                                                {argAccess}
                                            End Function)
         End Sub
@@ -387,6 +479,16 @@ Namespace MyNamespace
                           End Function).Do(Function(callInfo)
                                                {argAccess}
                                            End Function)
+            {method}(substitute:= mock, substituteCall:= Function(substitute) 
+                             Dim x = {call}
+                          End Function).Do(Function(callInfo)
+                                               {argAccess}
+                                           End Function)
+            {method}(substituteCall:= Function(substitute) 
+                             Dim x = {call}
+                          End Function, substitute:= mock).Do(Function(callInfo)
+                                               {argAccess}
+                                           End Function)
         End Sub
     End Class
 End Namespace
@@ -413,6 +515,16 @@ Namespace MyNamespace
             {method}(mock, Function(substitute) 
                              Dim x = {call}
                           End Function).Do(Function(callInfo)
+                                               {argAccess}
+                                           End Function)
+            {method}(substitute:= mock, substituteCall:= Function(substitute) 
+                             Dim x = {call}
+                          End Function).Do(Function(callInfo)
+                                               {argAccess}
+                                           End Function)
+            {method}(substituteCall:= Function(substitute) 
+                             Dim x = {call}
+                          End Function, substitute:= mock).Do(Function(callInfo)
                                                {argAccess}
                                            End Function)
         End Sub
@@ -451,6 +563,16 @@ Namespace MyNamespace
             {method}(mock, Function(substitute) 
                              Dim x = {call}
                           End Function).Do(Function(callInfo)
+                                               {argAccess}
+                                           End Function)
+            {method}(substitute:= mock, substituteCall:= Function(substitute) 
+                             Dim x = {call}
+                          End Function).Do(Function(callInfo)
+                                               {argAccess}
+                                           End Function)
+            {method}(substituteCall:= Function(substitute) 
+                             Dim x = {call}
+                          End Function, substitute:= mock).Do(Function(callInfo)
                                                {argAccess}
                                            End Function)
         End Sub
@@ -516,6 +638,16 @@ Namespace MyNamespace
                           End Function).Do(Function(callInfo)
                                                {argAccess}
                                            End Function)
+            {method}(substitute:= mock, substituteCall:= Function(substitute) 
+                             Dim x = {call}
+                          End Function).Do(Function(callInfo)
+                                               {argAccess}
+                                           End Function)
+            {method}(substituteCall:= Function(substitute) 
+                             Dim x = {call}
+                          End Function, substitute:= mock).Do(Function(callInfo)
+                                               {argAccess}
+                                           End Function)
         End Sub
     End Class
 End Namespace
@@ -546,6 +678,16 @@ Namespace MyNamespace
                           End Function).Do(Function(callInfo)
                                                {argAccess}
                                            End Function)
+            {method}(substitute:= mock, substituteCall:= Function(substitute) 
+                             Dim x = {call}
+                          End Function).Do(Function(callInfo)
+                                               {argAccess}
+                                           End Function)
+            {method}(substituteCall:= Function(substitute) 
+                             Dim x = {call}
+                          End Function, substitute:= mock).Do(Function(callInfo)
+                                               {argAccess}
+                                           End Function)
         End Sub
     End Class
 End Namespace
@@ -572,6 +714,16 @@ Namespace MyNamespace
                           End Function).Do(Function(callInfo)
                                                [|callInfo(1)|] = 1
                                            End Function)
+            {method}(substitute:= mock, substituteCall:= Function(substitute) 
+                             Dim x = {call}
+                          End Function).Do(Function(callInfo)
+                                               [|callInfo(1)|] = 1
+                                           End Function)
+            {method}(substituteCall:= Function(substitute) 
+                             Dim x = {call}
+                          End Function, substitute:= mock).Do(Function(callInfo)
+                                               [|callInfo(1)|] = 1
+                                           End Function)
         End Sub
     End Class
 End Namespace
@@ -595,6 +747,16 @@ Namespace MyNamespace
             {method}(mock, Function(substitute) 
                              Dim x = substitute.Bar(value)
                           End Function).Do(Function(callInfo)
+                                               callInfo(0) = 1
+                                           End Function)
+            {method}(substitute:= mock, substituteCall:= Function(substitute) 
+                             Dim x = substitute.Bar(value)
+                          End Function).Do(Function(callInfo)
+                                               callInfo(0) = 1
+                                           End Function)
+            {method}(substituteCall:= Function(substitute) 
+                             Dim x = substitute.Bar(value)
+                          End Function, substitute:= mock).Do(Function(callInfo)
                                                callInfo(0) = 1
                                            End Function)
         End Sub
@@ -623,6 +785,16 @@ Namespace MyNamespace
                           End Function).Do(Function(callInfo)
                                                callInfo(0) = 1
                                            End Function)
+            {method}(substitute:= mock, substituteCall:= Function(substitute) 
+                             Dim x = substitute.Bar(value)
+                          End Function).Do(Function(callInfo)
+                                               callInfo(0) = 1
+                                           End Function)
+            {method}(substituteCall:= Function(substitute) 
+                             Dim x = substitute.Bar(value)
+                          End Function, substitute:= mock).Do(Function(callInfo)
+                                               callInfo(0) = 1
+                                           End Function)
         End Sub
     End Class
 End Namespace
@@ -647,6 +819,16 @@ Namespace MyNamespace
             {method}(mock, Function(substitute) 
                              Dim x = substitute.Bar(value)
                           End Function).Do(Function(callInfo)
+                                               [|callInfo(1)|] = 1
+                                           End Function)
+            {method}(substitute:= mock, substituteCall:= Function(substitute) 
+                             Dim x = substitute.Bar(value)
+                          End Function).Do(Function(callInfo)
+                                               [|callInfo(1)|] = 1
+                                           End Function)
+            {method}(substituteCall:= Function(substitute) 
+                             Dim x = substitute.Bar(value)
+                          End Function, substitute:= mock).Do(Function(callInfo)
                                                [|callInfo(1)|] = 1
                                            End Function)
         End Sub
@@ -676,6 +858,16 @@ Namespace MyNamespace
                           End Function).Do(Function(callInfo)
                                                [|callInfo(0)|] = {right}
                                            End Function)
+            {method}(substitute:= mock, substituteCall:= Function(substitute) 
+                             Dim x = substitute.Bar(value)
+                          End Function).Do(Function(callInfo)
+                                               [|callInfo(0)|] = {right}
+                                           End Function)
+            {method}(substituteCall:= Function(substitute) 
+                             Dim x = substitute.Bar(value)
+                          End Function, substitute:= mock).Do(Function(callInfo)
+                                               [|callInfo(0)|] = {right}
+                                           End Function)
         End Sub
     End Class
 End Namespace
@@ -702,6 +894,16 @@ Namespace MyNamespace
             {method}(mock, Function(substitute) 
                              Dim x = substitute.Bar(value)
                           End Function).Do(Function(callInfo)
+                                               callInfo(0) = {right}
+                                           End Function)
+            {method}(substitute:= mock, substituteCall:= Function(substitute) 
+                             Dim x = substitute.Bar(value)
+                          End Function).Do(Function(callInfo)
+                                               callInfo(0) = {right}
+                                           End Function)
+            {method}(substituteCall:= Function(substitute) 
+                             Dim x = substitute.Bar(value)
+                          End Function, substitute:= mock).Do(Function(callInfo)
                                                callInfo(0) = {right}
                                            End Function)
         End Sub

--- a/tests/NSubstitute.Analyzers.Tests.VisualBasic/DiagnosticAnalyzersTests/CallInfoAnalyzerTests/ReturnsAsOrdinaryMethodTests.cs
+++ b/tests/NSubstitute.Analyzers.Tests.VisualBasic/DiagnosticAnalyzersTests/CallInfoAnalyzerTests/ReturnsAsOrdinaryMethodTests.cs
@@ -28,6 +28,14 @@ Namespace MyNamespace
                                {argAccess}
                                Return 1
                            End Function)
+            {method}(value:= returnedValue, returnThis:= Function(callInfo)
+                               {argAccess}
+                               Return 1
+                           End Function)
+            {method}(returnThis:= Function(callInfo)
+                               {argAccess}
+                               Return 1
+                           End Function, value:= returnedValue)
         End Sub
     End Class
 End Namespace";
@@ -54,6 +62,14 @@ Namespace MyNamespace
                                {argAccess}
                                Return 1
                            End Function)
+            {method}(value:= {call}, returnThis:= Function(callInfo)
+                               {argAccess}
+                               Return 1
+                           End Function)
+            {method}(returnThis:= Function(callInfo)
+                               {argAccess}
+                               Return 1
+                           End Function, value:= {call})
         End Sub
     End Class
 End Namespace
@@ -80,6 +96,14 @@ Namespace MyNamespace
                                {argAccess}
                                Return 1
                            End Function)
+            {method}(value:= {call}, returnThis:= Function(callInfo)
+                               {argAccess}
+                               Return 1
+                           End Function)
+            {method}(returnThis:= Function(callInfo)
+                               {argAccess}
+                               Return 1
+                           End Function, value:= {call})
         End Sub
     End Class
 End Namespace";
@@ -105,6 +129,14 @@ Namespace MyNamespace
                                    {argAccess}
                                    Return 1
                            End Function)
+            {method}(value:= {call}, returnThis:= Function(callInfo)
+                                   {argAccess}
+                                   Return 1
+                           End Function)
+            {method}(returnThis:= Function(callInfo)
+                                   {argAccess}
+                                   Return 1
+                           End Function, value:= {call})
         End Sub
     End Class
 End Namespace
@@ -219,6 +251,14 @@ Namespace MyNamespace
                                    {argAccess}
                                    Return 1
                            End Function)
+            {method}(value:= {call}, returnThis:= Function(callInfo)
+                                   {argAccess}
+                                   Return 1
+                           End Function)
+            {method}(returnThis:= Function(callInfo)
+                                   {argAccess}
+                                   Return 1
+                           End Function, value:= {call})
         End Sub
     End Class
 End Namespace";
@@ -253,6 +293,14 @@ Namespace MyNamespace
                                {argAccess}
                                Return 1
                            End Function)
+            {method}(value:= {call}, returnThis:= Function(callInfo)
+                               {argAccess}
+                               Return 1
+                           End Function)
+            {method}(returnThis:= Function(callInfo)
+                               {argAccess}
+                               Return 1
+                           End Function, value:= {call})
         End Sub
     End Class
 End Namespace
@@ -285,6 +333,14 @@ Namespace MyNamespace
                                {argAccess}
                                Return 1
                            End Function)
+            {method}(value:= {call}, returnThis:= Function(callInfo)
+                               {argAccess}
+                               Return 1
+                           End Function)
+            {method}(returnThis:= Function(callInfo)
+                               {argAccess}
+                               Return 1
+                           End Function, value:= {call})
         End Sub
     End Class
 End Namespace
@@ -320,6 +376,14 @@ Namespace MyNamespace
                                {argAccess}
                                Return 1
                            End Function)
+            {method}(value:= {call}, returnThis:= Function(callInfo)
+                               {argAccess}
+                               Return 1
+                           End Function)
+            {method}(returnThis:= Function(callInfo)
+                               {argAccess}
+                               Return 1
+                           End Function, value:= {call})
         End Sub
     End Class
 End Namespace
@@ -348,6 +412,14 @@ Namespace MyNamespace
                                {argAccess}
                                Return 1
                            End Function)
+            {method}(value:= {call}, returnThis:= Function(callInfo)
+                               {argAccess}
+                               Return 1
+                           End Function)
+            {method}(returnThis:= Function(callInfo)
+                               {argAccess}
+                               Return 1
+                           End Function, value:= {call})
         End Sub
     End Class
 End Namespace
@@ -376,6 +448,14 @@ Namespace MyNamespace
                                {argAccess}
                                Return 1
                            End Function)
+            {method}(value:= {call}, returnThis:= Function(callInfo)
+                               {argAccess}
+                               Return 1
+                           End Function)
+            {method}(returnThis:= Function(callInfo)
+                               {argAccess}
+                               Return 1
+                           End Function, value:= {call})
         End Sub
     End Class
 End Namespace
@@ -403,6 +483,14 @@ Namespace MyNamespace
                                {argAccess}
                                Return 1
                            End Function)
+            {method}(value:= {call}, returnThis:= Function(callInfo)
+                               {argAccess}
+                               Return 1
+                           End Function)
+            {method}(returnThis:= Function(callInfo)
+                               {argAccess}
+                               Return 1
+                           End Function, value:= {call})
         End Sub
     End Class
 End Namespace
@@ -439,6 +527,14 @@ Namespace MyNamespace
                                {argAccess}
                                Return 1
                            End Function)
+            {method}(value:= {call}, returnThis:= Function(callInfo)
+                               {argAccess}
+                               Return 1
+                           End Function)
+            {method}(returnThis:= Function(callInfo)
+                               {argAccess}
+                               Return 1
+                           End Function, value:= {call})
         End Sub
     End Class
 End Namespace
@@ -501,6 +597,14 @@ Namespace MyNamespace
                                {argAccess}
                                Return 1
                            End Function)
+            {method}(value:= {call}, returnThis:= Function(callInfo)
+                               {argAccess}
+                               Return 1
+                           End Function)
+            {method}(returnThis:= Function(callInfo)
+                               {argAccess}
+                               Return 1
+                           End Function, value:= {call})
         End Sub
     End Class
 End Namespace
@@ -530,6 +634,14 @@ Namespace MyNamespace
                                {argAccess}
                                Return 1
                            End Function)
+            {method}(value:= {call}, returnThis:= Function(callInfo)
+                               {argAccess}
+                               Return 1
+                           End Function)
+            {method}(returnThis:= Function(callInfo)
+                               {argAccess}
+                               Return 1
+                           End Function, value:= {call})
         End Sub
     End Class
 End Namespace
@@ -555,6 +667,14 @@ Namespace MyNamespace
                                [|callInfo(1)|] = 1
                                Return 1
                            End Function)
+            {method}(value:= {call}, returnThis:= Function(callInfo)
+                               [|callInfo(1)|] = 1
+                               Return 1
+                           End Function)
+            {method}(returnThis:= Function(callInfo)
+                               [|callInfo(1)|] = 1
+                               Return 1
+                           End Function, value:= {call})
         End Sub
     End Class
 End Namespace
@@ -579,6 +699,14 @@ Namespace MyNamespace
                                               callInfo(0) = 1
                                               Return 1
                                           End Function)
+            {method}(value:= substitute.Bar(value), returnThis:= Function(callInfo)
+                                              callInfo(0) = 1
+                                              Return 1
+                                          End Function)
+            {method}(returnThis:= Function(callInfo)
+                                              callInfo(0) = 1
+                                              Return 1
+                                          End Function, value:= substitute.Bar(value))
         End Sub
     End Class
 End Namespace
@@ -604,6 +732,14 @@ Namespace MyNamespace
                                               callInfo(0) = 1
                                               Return 1
                                           End Function)
+            {method}(value:= substitute.Bar(value), returnThis:= Function(callInfo)
+                                              callInfo(0) = 1
+                                              Return 1
+                                          End Function)
+            {method}(returnThis:= Function(callInfo)
+                                              callInfo(0) = 1
+                                              Return 1
+                                          End Function, value:= substitute.Bar(value))
         End Sub
     End Class
 End Namespace
@@ -629,6 +765,14 @@ Namespace MyNamespace
                                               [|callInfo(1)|] = 1
                                               Return 1
                                           End Function)
+            {method}(value:= substitute.Bar(value), returnThis:= Function(callInfo)
+                                              [|callInfo(1)|] = 1
+                                              Return 1
+                                          End Function)
+            {method}(returnThis:= Function(callInfo)
+                                              [|callInfo(1)|] = 1
+                                              Return 1
+                                          End Function, value:= substitute.Bar(value))
         End Sub
     End Class
 End Namespace
@@ -655,6 +799,14 @@ Namespace MyNamespace
                                               [|callInfo(0)|] = {right}
                                               Return 1
                                           End Function)
+            {method}(value:= substitute.Bar(value), returnThis:= Function(callInfo)
+                                              [|callInfo(0)|] = {right}
+                                              Return 1
+                                          End Function)
+            {method}(returnThis:= Function(callInfo)
+                                              [|callInfo(0)|] = {right}
+                                              Return 1
+                                          End Function, value:= substitute.Bar(value))
         End Sub
     End Class
 End Namespace
@@ -682,6 +834,14 @@ Namespace MyNamespace
                                               callInfo(0) = {right}
                                               Return 1
                                           End Function)
+            {method}(value:= substitute.Bar(value), returnThis:= Function(callInfo)
+                                              callInfo(0) = {right}
+                                              Return 1
+                                          End Function)
+            {method}(returnThis:= Function(callInfo)
+                                              callInfo(0) = {right}
+                                              Return 1
+                                          End Function, value:= substitute.Bar(value))
         End Sub
     End Class
 End Namespace

--- a/tests/NSubstitute.Analyzers.Tests.VisualBasic/DiagnosticAnalyzersTests/CallInfoAnalyzerTests/ThrowsAsOrdinaryMethodsTests.cs
+++ b/tests/NSubstitute.Analyzers.Tests.VisualBasic/DiagnosticAnalyzersTests/CallInfoAnalyzerTests/ThrowsAsOrdinaryMethodsTests.cs
@@ -29,6 +29,14 @@ Namespace MyNamespace
                                {argAccess}
                                Return New Exception()
                            End Function)
+            {method}(value:= returnedValue, createException:= Function(callInfo)
+                               {argAccess}
+                               Return New Exception()
+                           End Function)
+            {method}(createException:= Function(callInfo)
+                               {argAccess}
+                               Return New Exception()
+                           End Function, value:= returnedValue)
         End Sub
     End Class
 End Namespace";
@@ -55,6 +63,14 @@ Namespace MyNamespace
                                {argAccess}
                                Return New Exception()
                            End Function)
+            {method}(value:= {call}, createException:= Function(callInfo)
+                               {argAccess}
+                               Return New Exception()
+                           End Function)
+            {method}(createException:= Function(callInfo)
+                               {argAccess}
+                               Return New Exception()
+                           End Function, value:= {call})
         End Sub
     End Class
 End Namespace
@@ -82,6 +98,14 @@ Namespace MyNamespace
                                {argAccess}
                                Return New Exception()
                            End Function)
+            {method}(value:= {call}, createException:= Function(callInfo)
+                               {argAccess}
+                               Return New Exception()
+                           End Function)
+            {method}(createException:= Function(callInfo)
+                               {argAccess}
+                               Return New Exception()
+                           End Function, value:= {call})
         End Sub
     End Class
 End Namespace";
@@ -108,6 +132,14 @@ Namespace MyNamespace
                                    {argAccess}
                                    Return New Exception()
                            End Function)
+            {method}(value:= {call}, createException:= Function(callInfo)
+                                   {argAccess}
+                                   Return New Exception()
+                           End Function)
+            {method}(createException:= Function(callInfo)
+                                   {argAccess}
+                                   Return New Exception()
+                           End Function, value:= {call})
         End Sub
     End Class
 End Namespace
@@ -225,6 +257,14 @@ Namespace MyNamespace
                                    {argAccess}
                                    Return New Exception()
                            End Function)
+            {method}(value:= {call}, createException:= Function(callInfo)
+                                   {argAccess}
+                                   Return New Exception()
+                           End Function)
+            {method}(createException:= Function(callInfo)
+                                   {argAccess}
+                                   Return New Exception()
+                           End Function, value:= {call})
         End Sub
     End Class
 End Namespace";
@@ -259,6 +299,14 @@ Namespace MyNamespace
                                {argAccess}
                                Return New Exception()
                            End Function)
+            {method}(value:= {call}, createException:= Function(callInfo)
+                               {argAccess}
+                               Return New Exception()
+                           End Function)
+            {method}(createException:= Function(callInfo)
+                               {argAccess}
+                               Return New Exception()
+                           End Function, value:= {call})
         End Sub
     End Class
 End Namespace
@@ -292,6 +340,14 @@ Namespace MyNamespace
                                {argAccess}
                                Return New Exception()
                            End Function)
+            {method}(value:= {call}, createException:= Function(callInfo)
+                               {argAccess}
+                               Return New Exception()
+                           End Function)
+            {method}(createException:= Function(callInfo)
+                               {argAccess}
+                               Return New Exception()
+                           End Function, value:= {call})
         End Sub
     End Class
 End Namespace
@@ -327,6 +383,14 @@ Namespace MyNamespace
                                {argAccess}
                                Return New Exception()
                            End Function)
+            {method}(value:= {call}, createException:= Function(callInfo)
+                               {argAccess}
+                               Return New Exception()
+                           End Function)
+            {method}(createException:= Function(callInfo)
+                               {argAccess}
+                               Return New Exception()
+                           End Function, value:= {call})
         End Sub
     End Class
 End Namespace
@@ -356,6 +420,14 @@ Namespace MyNamespace
                                {argAccess}
                                Return New Exception()
                            End Function)
+            {method}(value:= {call}, createException:= Function(callInfo)
+                               {argAccess}
+                               Return New Exception()
+                           End Function)
+            {method}(createException:= Function(callInfo)
+                               {argAccess}
+                               Return New Exception()
+                           End Function, value:= {call})
         End Sub
     End Class
 End Namespace
@@ -385,6 +457,14 @@ Namespace MyNamespace
                                {argAccess}
                                Return New Exception()
                            End Function)
+            {method}(value:= {call}, createException:= Function(callInfo)
+                               {argAccess}
+                               Return New Exception()
+                           End Function)
+            {method}(createException:= Function(callInfo)
+                               {argAccess}
+                               Return New Exception()
+                           End Function, value:= {call})
         End Sub
     End Class
 End Namespace
@@ -413,6 +493,14 @@ Namespace MyNamespace
                                {argAccess}
                                Return New Exception()
                            End Function)
+            {method}(value:= {call}, createException:= Function(callInfo)
+                               {argAccess}
+                               Return New Exception()
+                           End Function)
+            {method}(createException:= Function(callInfo)
+                               {argAccess}
+                               Return New Exception()
+                           End Function, value:= {call})
         End Sub
     End Class
 End Namespace
@@ -450,6 +538,14 @@ Namespace MyNamespace
                                {argAccess}
                                Return New Exception()
                            End Function)
+            {method}(value:= {call}, createException:= Function(callInfo)
+                               {argAccess}
+                               Return New Exception()
+                           End Function)
+            {method}(createException:= Function(callInfo)
+                               {argAccess}
+                               Return New Exception()
+                           End Function, value:= {call})
         End Sub
     End Class
 End Namespace
@@ -516,6 +612,14 @@ Namespace MyNamespace
                                {argAccess}
                                Return New Exception()
                            End Function)
+            {method}(value:= {call}, createException:= Function(callInfo)
+                               {argAccess}
+                               Return New Exception()
+                           End Function)
+            {method}(createException:= Function(callInfo)
+                               {argAccess}
+                               Return New Exception()
+                           End Function, value:= {call})
         End Sub
     End Class
 End Namespace
@@ -548,6 +652,14 @@ Namespace MyNamespace
                                {argAccess}
                                Return New Exception()
                            End Function)
+            {method}(value:= {call}, createException:= Function(callInfo)
+                               {argAccess}
+                               Return New Exception()
+                           End Function)
+            {method}(createException:= Function(callInfo)
+                               {argAccess}
+                               Return New Exception()
+                           End Function, value:= {call})
         End Sub
     End Class
 End Namespace
@@ -575,6 +687,14 @@ Namespace MyNamespace
                                [|callInfo(1)|] = 1
                                Return New Exception()
                            End Function)
+            {method}(value:= {call}, createException:= Function(callInfo)
+                               [|callInfo(1)|] = 1
+                               Return New Exception()
+                           End Function)
+            {method}(createException:= Function(callInfo)
+                               [|callInfo(1)|] = 1
+                               Return New Exception()
+                           End Function, value:= {call})
         End Sub
     End Class
 End Namespace
@@ -601,6 +721,14 @@ Namespace MyNamespace
                                               callInfo(0) = 1
                                               Return New Exception()
                                           End Function)
+            {method}(value:= substitute.Bar(value), createException:= Function(callInfo)
+                                              callInfo(0) = 1
+                                              Return New Exception()
+                                          End Function)
+            {method}(createException:= Function(callInfo)
+                                              callInfo(0) = 1
+                                              Return New Exception()
+                                          End Function, value:= substitute.Bar(value))
         End Sub
     End Class
 End Namespace
@@ -628,6 +756,14 @@ Namespace MyNamespace
                                               callInfo(0) = 1
                                               Return New Exception()
                                           End Function)
+            {method}(value:= substitute.Bar(value), createException:= Function(callInfo)
+                                              callInfo(0) = 1
+                                              Return New Exception()
+                                          End Function)
+            {method}(createException:= Function(callInfo)
+                                              callInfo(0) = 1
+                                              Return New Exception()
+                                          End Function, value:= substitute.Bar(value))
         End Sub
     End Class
 End Namespace
@@ -655,6 +791,14 @@ Namespace MyNamespace
                                               [|callInfo(1)|] = 1
                                               Return New Exception()
                                           End Function)
+            {method}(value:= substitute.Bar(value), createException:= Function(callInfo)
+                                              [|callInfo(1)|] = 1
+                                              Return New Exception()
+                                          End Function)
+            {method}(createException:= Function(callInfo)
+                                              [|callInfo(1)|] = 1
+                                              Return New Exception()
+                                          End Function, value:= substitute.Bar(value))
         End Sub
     End Class
 End Namespace
@@ -683,6 +827,14 @@ Namespace MyNamespace
                                               [|callInfo(0)|] = {right}
                                               Return New Exception()
                                           End Function)
+            {method}(value:= substitute.Bar(value), createException:= Function(callInfo)
+                                              [|callInfo(0)|] = {right}
+                                              Return New Exception()
+                                          End Function)
+            {method}(createException:= Function(callInfo)
+                                              [|callInfo(0)|] = {right}
+                                              Return New Exception()
+                                          End Function, value:= substitute.Bar(value))
         End Sub
     End Class
 End Namespace
@@ -713,6 +865,14 @@ Namespace MyNamespace
                                               callInfo(0) = {right}
                                               Return New Exception()
                                           End Function)
+            {method}(value:= substitute.Bar(value), createException:= Function(callInfo)
+                                              callInfo(0) = {right}
+                                              Return New Exception()
+                                          End Function)
+            {method}(createException:= Function(callInfo)
+                                              callInfo(0) = {right}
+                                              Return New Exception()
+                                          End Function, value:= substitute.Bar(value))
         End Sub
     End Class
 End Namespace

--- a/tests/NSubstitute.Analyzers.Tests.VisualBasic/DiagnosticAnalyzersTests/NonSubstitutableMemberAnalyzerTests/ReturnsAsOrdinaryMethodTests.cs
+++ b/tests/NSubstitute.Analyzers.Tests.VisualBasic/DiagnosticAnalyzersTests/NonSubstitutableMemberAnalyzerTests/ReturnsAsOrdinaryMethodTests.cs
@@ -28,6 +28,8 @@ Namespace MyNamespace
         Public Sub Test()
             Dim substitute = NSubstitute.Substitute.[For](Of Foo)()
             {method}([|substitute.Bar()|], 1)
+            {method}(value:= [|substitute.Bar()|], returnThis:= 1)
+            {method}(returnThis:= 1, value:= [|substitute.Bar()|])
         End Sub
     End Class
 End Namespace
@@ -47,6 +49,8 @@ Namespace MyNamespace
     Public Class FooTests
         Public Sub Test()
             {method}([|{literal}|], {literal})
+            {method}(value:= [|{literal}|], returnThis:= {literal})
+            {method}(returnThis:= {literal}, value:= [|{literal}|])
         End Sub
     End Class
 End Namespace
@@ -71,6 +75,8 @@ Namespace MyNamespace
 
         Public Sub Test()
             {method}([|Foo.Bar()|], 1)
+            {method}(value:= [|Foo.Bar()|], returnThis:= 1)
+            {method}(returnThis:= 1, value:= [|Foo.Bar()|])
         End Sub
     End Class
 End Namespace
@@ -96,6 +102,8 @@ Namespace MyNamespace
         Public Sub Test()
             Dim substitute = NSubstitute.Substitute.[For](Of Foo)()
             {method}(substitute.Bar(), 1)
+            {method}(value:= substitute.Bar(), returnThis:= 1)
+            {method}(returnThis:= 1, value:= substitute.Bar())
         End Sub
     End Class
 End Namespace
@@ -129,6 +137,8 @@ Namespace MyNamespace
         Public Sub Test()
             Dim substitute = NSubstitute.Substitute.[For](Of Foo2)()
             {method}(substitute.Bar(), 1)
+            {method}(value:= substitute.Bar(), returnThis:= 1)
+            {method}(returnThis:= 1, value:= substitute.Bar())
         End Sub
     End Class
 End Namespace
@@ -155,6 +165,8 @@ Namespace MyNamespace
             Dim substitute = NSubstitute.Substitute.[For](Of Foo)()
             Dim returnValue = substitute.Bar()
             {method}(returnValue, 1)
+            {method}(value:= returnValue, returnThis:= 1)
+            {method}(returnThis:= 1, value:= returnValue)
         End Sub
     End Class
 End Namespace
@@ -174,6 +186,8 @@ Namespace MyNamespace
         Public Sub Test()
             Dim substitute = NSubstitute.Substitute.[For](Of Func(Of Integer))()
             {method}(substitute(), 1)
+            {method}(value:= substitute(), returnThis:= 1)
+            {method}(returnThis:= 1, value:= substitute())
         End Sub
     End Class
 End Namespace
@@ -207,6 +221,7 @@ Namespace MyNamespace
         Public Sub Test()
             Dim substitute = NSubstitute.Substitute.[For](Of Foo2)()
             {method}([|substitute.Bar()|], 1)
+            {method}(value:= [|substitute.Bar()|], returnThis:= 1)
         End Sub
     End Class
 End Namespace
@@ -230,6 +245,8 @@ Namespace MyNamespace
         Public Sub Test()
             Dim substitute = NSubstitute.Substitute.[For](Of Foo)()
             {method}(substitute.Bar(), 1)
+            {method}(value:= substitute.Bar(), returnThis:= 1)
+            {method}(returnThis:= 1, value:= substitute.Bar())
         End Sub
     End Class
 End Namespace
@@ -255,6 +272,7 @@ Namespace MyNamespace
         Public Sub Test()
             Dim substitute = NSubstitute.Substitute.[For](Of IFoo)()
             {method}(substitute.Bar(), 1)
+            {method}(value:= substitute.Bar(), returnThis:= 1)
         End Sub
     End Class
 End Namespace
@@ -279,6 +297,8 @@ Namespace MyNamespace
         Public Sub Test()
             Dim substitute = NSubstitute.Substitute.[For](Of IFoo)()
             {method}(substitute.Bar, 1)
+            {method}(value:= substitute.Bar, returnThis:= 1)
+            {method}(returnThis:= 1, value:= substitute.Bar)
         End Sub
     End Class
 End Namespace
@@ -302,6 +322,8 @@ Namespace MyNamespace
         Public Sub Test()
             Dim substitute = NSubstitute.Substitute.[For](Of IFoo(Of Integer))()
             {method}(substitute.Bar(Of Integer), 1)
+            {method}(value:= substitute.Bar(Of Integer), returnThis:= 1)
+            {method}(returnThis:= 1, value:= substitute.Bar(Of Integer))
         End Sub
     End Class
 End Namespace";
@@ -325,6 +347,8 @@ Namespace MyNamespace
         Public Sub Test()
             Dim substitute = NSubstitute.Substitute.For(Of Foo)
             {method}(substitute.Bar, 1)
+            {method}(value:= substitute.Bar, returnThis:= 1)
+            {method}(returnThis:= 1, value:= substitute.Bar)
         End Sub
     End Class
 End Namespace";
@@ -348,6 +372,8 @@ Namespace MyNamespace
         Public Sub Test()
             Dim substitute = NSubstitute.Substitute.For(Of IFoo)
             {method}(substitute(1), 1)
+            {method}(value:= substitute(1), returnThis:= 1)
+            {method}(returnThis:= 1, value:= substitute(1))
         End Sub
     End Class
 End Namespace";
@@ -373,6 +399,8 @@ Namespace MyNamespace
         Public Sub Test()
             Dim substitute = NSubstitute.Substitute.For(Of Foo)
             {method}(substitute.Bar, 1)
+            {method}(value:= substitute.Bar, returnThis:= 1)
+            {method}(returnThis:= 1, value:= substitute.Bar)
         End Sub
     End Class
 End Namespace";
@@ -399,6 +427,8 @@ Namespace MyNamespace
         Public Sub Test()
             Dim substitute = NSubstitute.Substitute.For(Of Foo)
             {method}([|substitute.Bar|], 1)
+            {method}(value:= [|substitute.Bar|], returnThis:= 1)
+            {method}(returnThis:= 1, value:= [|substitute.Bar|])
         End Sub
     End Class
 End Namespace";
@@ -431,6 +461,8 @@ Namespace MyNamespace
         Public Sub Test()
             Dim substitute = NSubstitute.Substitute.For(Of Foo)
             {method}(substitute(1), 1)
+            {method}(value:= substitute(1), returnThis:= 1)
+            {method}(returnThis:= 1, value:= substitute(1))
         End Sub
     End Class
 End Namespace";
@@ -459,6 +491,8 @@ Namespace MyNamespace
         Public Sub Test()
             Dim substitute = NSubstitute.Substitute.For(Of Foo)
             {method}([|substitute(1)|], 1)
+            {method}(value:= [|substitute(1)|], returnThis:= 1)
+            {method}(returnThis:= 1, value:= [|substitute(1)|])
         End Sub
     End Class
 End Namespace";
@@ -517,6 +551,8 @@ Namespace MyNamespace
             Dim substitute = NSubstitute.Substitute.[For](Of Foo)()
             {method}(substitute.Bar, 1)
             {method}([|substitute.FooBar|], 1)
+            {method}(value:= [|substitute.FooBar|], returnThis:= 1)
+            {method}(returnThis:= 1, value:= [|substitute.FooBar|])
         End Sub
     End Class
 End Namespace
@@ -542,6 +578,8 @@ Namespace MyNamespace
             Dim substitute = NSubstitute.Substitute.[For](Of Foo(Of Integer))()
             {method}(substitute.Bar, 1)
             {method}([|substitute.FooBar|], 1)
+            {method}(value:= [|substitute.FooBar|], returnThis:= 1)
+            {method}(returnThis:= 1, value:= [|substitute.FooBar|])
         End Sub
     End Class
 End Namespace
@@ -572,6 +610,8 @@ Namespace MyNamespace
             Dim substitute = NSubstitute.Substitute.[For](Of Foo)()
             {method}(substitute.Bar(1, 2), 1)
             {method}([|substitute.Bar(1)|], 1)
+            {method}(value:= [|substitute.Bar(1)|], returnThis:= 1)
+            {method}(returnThis:= 1, value:= [|substitute.Bar(1)|])
         End Sub
     End Class
 End Namespace
@@ -602,6 +642,8 @@ Namespace MyNamespace
             Dim substitute = NSubstitute.Substitute.[For](Of Foo)()
             {method}(substitute.Bar(Of Integer)(1, 2), 1)
             {method}([|substitute.Bar(1)|], 1)
+            {method}(value:= [|substitute.Bar(1)|], returnThis:= 1)
+            {method}(returnThis:= 1, value:= [|substitute.Bar(1)|])
         End Sub
     End Class
 End Namespace
@@ -636,6 +678,8 @@ Namespace MyNamespace
             Dim substitute = NSubstitute.Substitute.[For](Of Foo)()
             {method}(substitute(1 ,2), 1)
             {method}([|substitute(1)|], 1)
+            {method}(value:= [|substitute(1)|], returnThis:= 1)
+            {method}(returnThis:= 1, value:= [|substitute(1)|])
         End Sub
     End Class
 End Namespace
@@ -670,6 +714,8 @@ Namespace MyNamespace
             Dim substitute = NSubstitute.Substitute.[For](Of Foo(Of Integer))()
             {method}(substitute(1 ,2), 1)
             {method}([|substitute(1)|], 1)
+            {method}(value:= [|substitute(1)|], returnThis:= 1)
+            {method}(returnThis:= 1, value:= [|substitute(1)|])
         End Sub
     End Class
 End Namespace
@@ -719,6 +765,7 @@ Namespace MyNamespace
             {method}(substitute(1), 1)
             {method}(substitute.Bar, 1)
             {method}(substitute.FooBar(), 1)
+
             Dim substituteFooBarBar = NSubstitute.Substitute.[For](Of FooBarBar)()
             {method}([|substituteFooBarBar(1)|], 1)
             {method}([|substituteFooBarBar.Bar|], 1)
@@ -783,6 +830,7 @@ Namespace MyNamespace
             {method}(substitute(1), 1)
             {method}(substitute.Bar, 1)
             {method}(substitute.FooBar(), 1)
+
             Dim substituteFooBarBar = NSubstitute.Substitute.[For](Of FooBarBar(Of Integer))()
             {method}([|substituteFooBarBar(1)|], 1)
             {method}([|substituteFooBarBar.Bar|], 1)
@@ -850,6 +898,7 @@ Namespace MyNamespace
             {method}(substitute(1), 1)
             {method}(substitute.Bar, 1)
             {method}(substitute.FooBar(), 1)
+
             Dim substituteFooBarBar = NSubstitute.Substitute.[For](Of FooBarBar)()
             {method}([|substituteFooBarBar(1)|], 1)
             {method}([|substituteFooBarBar.Bar|], 1)
@@ -887,6 +936,8 @@ Namespace MyNamespace
             Dim substitute = NSubstitute.Substitute.[For](Of IFoo)()
             {method}(substitute.GetBar(), 1)
             {method}([|substitute.GetFooBar()|], 1)
+            {method}(value:= [|substitute.GetFooBar()|], returnThis:= 1)
+            {method}(returnThis:= 1, value:= [|substitute.GetFooBar()|])
         End Sub
     End Class
 
@@ -940,6 +991,8 @@ Namespace MyNamespace
         Public Sub Test()
             Dim substitute = NSubstitute.Substitute.[For](Of Foo)()
             Dim x = {method}([|substitute{call}|], 1)
+            Dim y = {method}(value:= [|substitute{call}|], returnThis:= 1)
+            Dim z = {method}(returnThis:= 1, value:= [|substitute{call}|])
         End Sub
     End Class
 End Namespace";
@@ -974,6 +1027,8 @@ Namespace MyNamespace
         Public Sub Test()
             Dim substitute = NSubstitute.Substitute.[For](Of Foo)()
             Dim x = {method}(substitute{call}, 1)
+            Dim y = {method}(value:= substitute{call}, returnThis:= 1)
+            Dim z = {method}(returnThis:= 1, value:= substitute{call})
         End Sub
     End Class
 End Namespace";
@@ -1006,6 +1061,8 @@ Namespace MyNamespace
         Public Sub Test()
             Dim substitute = NSubstitute.Substitute.[For](Of Foo)()
             Dim x = {method}([|substitute{call}|], 1)
+            Dim y = {method}(value:= [|substitute{call}|], returnThis:= 1)
+            Dim z = {method}(returnThis:= 1, value:= [|substitute{call}|])
         End Sub
     End Class
 End Namespace";
@@ -1036,6 +1093,8 @@ Namespace MyNamespace
         Public Sub Test()
             Dim substitute = NSubstitute.Substitute.[For](Of Foo)()
             Dim x = {method}(substitute{call}, 1)
+            Dim y = {method}(value:= substitute{call}, returnThis:= 1)
+            Dim z = {method}(returnThis:= 1, value:= substitute{call})
         End Sub
     End Class
 End Namespace";

--- a/tests/NSubstitute.Analyzers.Tests.VisualBasic/DiagnosticAnalyzersTests/NonSubstitutableMemberAnalyzerTests/ThrowsAsOrdinaryMethodTests.cs
+++ b/tests/NSubstitute.Analyzers.Tests.VisualBasic/DiagnosticAnalyzersTests/NonSubstitutableMemberAnalyzerTests/ThrowsAsOrdinaryMethodTests.cs
@@ -29,7 +29,8 @@ Namespace MyNamespace
 
         Public Sub Test()
             Dim substitute = NSubstitute.Substitute.[For](Of Foo)()
-            {method}([|substitute.Bar()|], New Exception())
+            {method}(value:= [|substitute.Bar()|], ex:= New Exception())
+            {method}(ex:= New Exception(), value:= [|substitute.Bar()|])
         End Sub
     End Class
 End Namespace
@@ -48,6 +49,8 @@ Namespace MyNamespace
     Public Class FooTests
         Public Sub Test()
             {method}([|{literal}|], New Exception())
+            {method}(value:= [|{literal}|], ex:= New Exception())
+            {method}(ex:= New Exception(), value:= [|{literal}|])
         End Sub
     End Class
 End Namespace
@@ -74,6 +77,8 @@ Namespace MyNamespace
 
         Public Sub Test()
             {method}([|Foo.Bar()|], New Exception())
+            {method}(value:= [|Foo.Bar()|], ex:= New Exception())
+            {method}(ex:= New Exception(), value:= [|Foo.Bar()|])
         End Sub
     End Class
 End Namespace
@@ -101,6 +106,7 @@ Namespace MyNamespace
         Public Sub Test()
             Dim substitute = NSubstitute.Substitute.[For](Of Foo)()
             {method}(substitute.Bar(), New Exception())
+            {method}(value:= substitute.Bar(), ex:= New Exception())
         End Sub
     End Class
 End Namespace
@@ -136,6 +142,8 @@ Namespace MyNamespace
         Public Sub Test()
             Dim substitute = NSubstitute.Substitute.[For](Of Foo2)()
             {method}(substitute.Bar(), New Exception())
+            {method}(value:= substitute.Bar(), ex:= New Exception())
+            {method}(ex:= New Exception(), value:= substitute.Bar())
         End Sub
     End Class
 End Namespace
@@ -164,6 +172,8 @@ Namespace MyNamespace
             Dim substitute = NSubstitute.Substitute.[For](Of Foo)()
             Dim returnValue = substitute.Bar()
             {method}(returnValue, New Exception())
+            {method}(value:= returnValue, ex:= New Exception())
+            {method}(ex:= New Exception(), value:= returnValue)
         End Sub
     End Class
 End Namespace
@@ -184,6 +194,8 @@ Namespace MyNamespace
         Public Sub Test()
             Dim substitute = NSubstitute.Substitute.[For](Of Func(Of Integer))()
             {method}(substitute(), New Exception())
+            {method}(value:= substitute(), ex:= New Exception())
+            {method}(ex:= New Exception(), value:= substitute())
         End Sub
     End Class
 End Namespace
@@ -219,6 +231,8 @@ Namespace MyNamespace
         Public Sub Test()
             Dim substitute = NSubstitute.Substitute.[For](Of Foo2)()
             {method}([|substitute.Bar()|], New Exception())
+            {method}(value:= [|substitute.Bar()|], ex:= New Exception())
+            {method}(ex:= New Exception(), value:= [|substitute.Bar()|])
         End Sub
     End Class
 End Namespace
@@ -244,6 +258,8 @@ Namespace MyNamespace
         Public Sub Test()
             Dim substitute = NSubstitute.Substitute.[For](Of Foo)()
             {method}(substitute.Bar(), New Exception())
+            {method}(value:= substitute.Bar(), ex:= New Exception())
+            {method}(ex:= New Exception(), value:= substitute.Bar())
         End Sub
     End Class
 End Namespace
@@ -271,6 +287,8 @@ Namespace MyNamespace
         Public Sub Test()
             Dim substitute = NSubstitute.Substitute.[For](Of IFoo)()
             {method}(substitute.Bar(), New Exception())
+            {method}(value:= substitute.Bar(), ex:= New Exception())
+            {method}(ex:= New Exception(), value:= substitute.Bar())
         End Sub
     End Class
 End Namespace
@@ -297,6 +315,8 @@ Namespace MyNamespace
         Public Sub Test()
             Dim substitute = NSubstitute.Substitute.[For](Of IFoo)()
             {method}(substitute.Bar, New Exception())
+            {method}(value:= substitute.Bar, ex:= New Exception())
+            {method}(ex:= New Exception(), value:= substitute.Bar)
         End Sub
     End Class
 End Namespace
@@ -322,6 +342,8 @@ Namespace MyNamespace
         Public Sub Test()
             Dim substitute = NSubstitute.Substitute.[For](Of IFoo(Of Integer))()
             {method}(substitute.Bar(Of Integer), New Exception())
+            {method}(value:= substitute.Bar(Of Integer), ex:= New Exception())
+            {method}(ex:= New Exception(), value:= substitute.Bar(Of Integer))
         End Sub
     End Class
 End Namespace";
@@ -347,6 +369,8 @@ Namespace MyNamespace
         Public Sub Test()
             Dim substitute = NSubstitute.Substitute.For(Of Foo)
             {method}(substitute.Bar, New Exception())
+            {method}(value:= substitute.Bar, ex:= New Exception())
+            {method}(ex:= New Exception(), value:= substitute.Bar)
         End Sub
     End Class
 End Namespace";
@@ -372,6 +396,8 @@ Namespace MyNamespace
         Public Sub Test()
             Dim substitute = NSubstitute.Substitute.For(Of IFoo)
             {method}(substitute(1), New Exception())
+            {method}(value:= substitute(1), ex:= New Exception())
+            {method}(ex:= New Exception(), value:= substitute(1))
         End Sub
     End Class
 End Namespace";
@@ -399,6 +425,8 @@ Namespace MyNamespace
         Public Sub Test()
             Dim substitute = NSubstitute.Substitute.For(Of Foo)
             {method}(substitute.Bar, New Exception())
+            {method}(value:= substitute.Bar, ex:= New Exception())
+            {method}(ex:= New Exception(), value:= substitute.Bar)
         End Sub
     End Class
 End Namespace";
@@ -427,6 +455,8 @@ Namespace MyNamespace
         Public Sub Test()
             Dim substitute = NSubstitute.Substitute.For(Of Foo)
             {method}([|substitute.Bar|], New Exception())
+            {method}(value:= [|substitute.Bar|], ex:= New Exception())
+            {method}(ex:= New Exception(), value:= [|substitute.Bar|])
         End Sub
     End Class
 End Namespace";
@@ -460,6 +490,8 @@ Namespace MyNamespace
         Public Sub Test()
             Dim substitute = NSubstitute.Substitute.For(Of Foo)
             {method}(substitute(1), New Exception())
+            {method}(value:= substitute(1), ex:= New Exception())
+            {method}(ex:= New Exception(), value:= substitute(1))
         End Sub
     End Class
 End Namespace";
@@ -489,6 +521,8 @@ Namespace MyNamespace
         Public Sub Test()
             Dim substitute = NSubstitute.Substitute.For(Of Foo)
             {method}([|substitute(1)|], New Exception())
+            {method}(value:= [|substitute(1)|], ex:= New Exception())
+            {method}(ex:= New Exception(), value:= [|substitute(1)|])
         End Sub
     End Class
 End Namespace";
@@ -549,6 +583,8 @@ Namespace MyNamespace
             Dim substitute = NSubstitute.Substitute.[For](Of Foo)()
             {method}(substitute.Bar, New Exception())
             {method}([|substitute.FooBar|], New Exception())
+            {method}(value:= [|substitute.FooBar|], ex:= New Exception())
+            {method}(ex:= New Exception(), value:= [|substitute.FooBar|])
         End Sub
     End Class
 End Namespace
@@ -576,6 +612,8 @@ Namespace MyNamespace
             Dim substitute = NSubstitute.Substitute.[For](Of Foo(Of Integer))()
             {method}(substitute.Bar, New Exception())
             {method}([|substitute.FooBar|], New Exception())
+            {method}(value:= [|substitute.FooBar|], ex:= New Exception())
+            {method}(ex:= New Exception(), value:= [|substitute.FooBar|])
         End Sub
     End Class
 End Namespace
@@ -608,6 +646,8 @@ Namespace MyNamespace
             Dim substitute = NSubstitute.Substitute.[For](Of Foo)()
             {method}(substitute.Bar(1, 2), New Exception())
             {method}([|substitute.Bar(1)|], New Exception())
+            {method}(value:= [|substitute.Bar(1)|], ex:= New Exception())
+            {method}(ex:= New Exception(), value:= [|substitute.Bar(1)|])
         End Sub
     End Class
 End Namespace
@@ -640,6 +680,8 @@ Namespace MyNamespace
             Dim substitute = NSubstitute.Substitute.[For](Of Foo)()
             {method}(substitute.Bar(Of Integer)(1, 2), New Exception())
             {method}([|substitute.Bar(1)|], New Exception())
+            {method}(value:= [|substitute.Bar(1)|], ex:= New Exception())
+            {method}(ex:= New Exception(), value:= [|substitute.Bar(1)|])
         End Sub
     End Class
 End Namespace
@@ -676,6 +718,8 @@ Namespace MyNamespace
             Dim substitute = NSubstitute.Substitute.[For](Of Foo)()
             {method}(substitute(1 ,2), New Exception())
             {method}([|substitute(1)|], New Exception())
+            {method}(value:= [|substitute(1)|], ex:= New Exception())
+            {method}(ex:= New Exception(), value:= [|substitute(1)|])
         End Sub
     End Class
 End Namespace
@@ -712,6 +756,8 @@ Namespace MyNamespace
             Dim substitute = NSubstitute.Substitute.[For](Of Foo(Of Integer))()
             {method}(substitute(1 ,2), New Exception())
             {method}([|substitute(1)|], New Exception())
+            {method}(value:= [|substitute(1)|], ex:= New Exception())
+            {method}(ex:= New Exception(), value:= [|substitute(1)|])
         End Sub
     End Class
 End Namespace
@@ -764,6 +810,7 @@ Namespace MyNamespace
             {method}(substitute.Bar, New Exception())
             {method}(substitute.FooBar(), New Exception())
             Dim substituteFooBarBar = NSubstitute.Substitute.[For](Of FooBarBar)()
+
             {method}([|substituteFooBarBar(1)|], New Exception())
             {method}([|substituteFooBarBar.Bar|], New Exception())
             {method}([|substituteFooBarBar.FooBar()|], New Exception())
@@ -830,6 +877,7 @@ Namespace MyNamespace
             {method}(substitute.Bar, New Exception())
             {method}(substitute.FooBar(), New Exception())
             Dim substituteFooBarBar = NSubstitute.Substitute.[For](Of FooBarBar(Of Integer))()
+
             {method}([|substituteFooBarBar(1)|], New Exception())
             {method}([|substituteFooBarBar.Bar|], New Exception())
             {method}([|substituteFooBarBar.FooBar()|], New Exception())
@@ -899,6 +947,7 @@ Namespace MyNamespace
             {method}(substitute.Bar, New Exception())
             {method}(substitute.FooBar(), New Exception())
             Dim substituteFooBarBar = NSubstitute.Substitute.[For](Of FooBarBar)()
+
             {method}([|substituteFooBarBar(1)|], New Exception())
             {method}([|substituteFooBarBar.Bar|], New Exception())
             {method}([|substituteFooBarBar.FooBar()|], New Exception())
@@ -937,6 +986,8 @@ Namespace MyNamespace
             Dim substitute = NSubstitute.Substitute.[For](Of IFoo)()
             {method}(substitute.GetBar(), New Exception())
             {method}([|substitute.GetFooBar()|], New Exception())
+            {method}(value:= [|substitute.GetFooBar()|], ex:= New Exception())
+            {method}(ex:= New Exception(), value:= [|substitute.GetFooBar()|])
         End Sub
     End Class
 
@@ -992,6 +1043,8 @@ Namespace MyNamespace
         Public Sub Test()
             Dim substitute = NSubstitute.Substitute.[For](Of Foo)()
             Dim x = {method}([|substitute{call}|], New Exception())
+            Dim y = {method}(value:= [|substitute{call}|], ex:= New Exception())
+            Dim z = {method}(ex:= New Exception(), value:= [|substitute{call}|])
         End Sub
     End Class
 End Namespace";
@@ -1028,6 +1081,8 @@ Namespace MyNamespace
         Public Sub Test()
             Dim substitute = NSubstitute.Substitute.[For](Of Foo)()
             Dim x = {method}(substitute{call}, New Exception())
+            Dim y = {method}(value:= substitute{call}, ex:= New Exception())
+            Dim z = {method}(ex:= New Exception(), value:= substitute{call})
         End Sub
     End Class
 End Namespace";
@@ -1062,6 +1117,8 @@ Namespace MyNamespace
         Public Sub Test()
             Dim substitute = NSubstitute.Substitute.[For](Of Foo)()
             Dim x = {method}([|substitute{call}|], New Exception())
+            Dim y = {method}(value:= [|substitute{call}|], ex:= New Exception())
+            Dim z = {method}(ex:= New Exception(), value:= [|substitute{call}|])
         End Sub
     End Class
 End Namespace";
@@ -1094,6 +1151,8 @@ Namespace MyNamespace
         Public Sub Test()
             Dim substitute = NSubstitute.Substitute.[For](Of Foo)()
             Dim x = {method}(substitute{call}, New Exception())
+            Dim y = {method}(value:= substitute{call}, ex:= New Exception())
+            Dim z = {method}(ex:= New Exception(), value:= substitute{call})
         End Sub
     End Class
 End Namespace";

--- a/tests/NSubstitute.Analyzers.Tests.VisualBasic/DiagnosticAnalyzersTests/NonSubstitutableMemberReceivedAnalyzerTests/ReceivedAsOrdinaryMethodTests.cs
+++ b/tests/NSubstitute.Analyzers.Tests.VisualBasic/DiagnosticAnalyzersTests/NonSubstitutableMemberReceivedAnalyzerTests/ReceivedAsOrdinaryMethodTests.cs
@@ -5,17 +5,32 @@ namespace NSubstitute.Analyzers.Tests.VisualBasic.DiagnosticAnalyzersTests.NonSu
 
 [CombinatoryData(
     "ReceivedExtensions.Received(substitute, Quantity.None())",
+    "ReceivedExtensions.Received(substitute:= substitute, requiredQuantity:= Quantity.None())",
+    "ReceivedExtensions.Received(requiredQuantity:= Quantity.None(), substitute:= substitute)",
     "ReceivedExtensions.Received(Of Foo)(substitute, Quantity.None())",
+    "ReceivedExtensions.Received(Of Foo)(substitute:= substitute, requiredQuantity:= Quantity.None())",
+    "ReceivedExtensions.Received(Of Foo)(requiredQuantity:= Quantity.None(), substitute:= substitute)",
     "SubstituteExtensions.Received(substitute)",
+    "SubstituteExtensions.Received(substitute:= substitute)",
     "SubstituteExtensions.Received(Of Foo)(substitute)",
+    "SubstituteExtensions.Received(Of Foo)(substitute:= substitute)",
     "ReceivedExtensions.ReceivedWithAnyArgs(substitute, Quantity.None())",
-    "ReceivedExtensions.ReceivedWithAnyArgs(Of Foo)(substitute, Quantity.None())",
+    "ReceivedExtensions.ReceivedWithAnyArgs(substitute:= substitute, requiredQuantity:= Quantity.None())",
+    "ReceivedExtensions.ReceivedWithAnyArgs(requiredQuantity:= Quantity.None(), substitute:= substitute)",
+    "ReceivedExtensions.ReceivedWithAnyArgs(Of Foo)(substitute:= substitute, requiredQuantity:= Quantity.None())",
+    "ReceivedExtensions.ReceivedWithAnyArgs(Of Foo)(requiredQuantity:= Quantity.None(), substitute:= substitute)",
     "SubstituteExtensions.ReceivedWithAnyArgs(substitute)",
+    "SubstituteExtensions.ReceivedWithAnyArgs(substitute:= substitute)",
     "SubstituteExtensions.ReceivedWithAnyArgs(Of Foo)(substitute)",
+    "SubstituteExtensions.ReceivedWithAnyArgs(Of Foo)(substitute:= substitute)",
     "SubstituteExtensions.DidNotReceive(substitute)",
+    "SubstituteExtensions.DidNotReceive(substitute:= substitute)",
     "SubstituteExtensions.DidNotReceive(Of Foo)(substitute)",
+    "SubstituteExtensions.DidNotReceive(Of Foo)(substitute:= substitute)",
     "SubstituteExtensions.DidNotReceiveWithAnyArgs(substitute)",
-    "SubstituteExtensions.DidNotReceiveWithAnyArgs(Of Foo)(substitute)")]
+    "SubstituteExtensions.DidNotReceiveWithAnyArgs(substitute:= substitute)",
+    "SubstituteExtensions.DidNotReceiveWithAnyArgs(Of Foo)(substitute)",
+    "SubstituteExtensions.DidNotReceiveWithAnyArgs(Of Foo)(substitute:= substitute)")]
 public class ReceivedAsOrdinaryMethodTests : NonSubstitutableMemberReceivedDiagnosticVerifier
 {
     public override async Task ReportsDiagnostics_WhenCheckingReceivedCallsForNonVirtualMethod(string method)
@@ -106,17 +121,33 @@ End Namespace
 
     [CombinatoryData(
         "ReceivedExtensions.Received(substitute, Quantity.None())",
+        "ReceivedExtensions.Received(substitute:= substitute, requiredQuantity:= Quantity.None())",
+        "ReceivedExtensions.Received(requiredQuantity:= Quantity.None(), substitute:= substitute)",
         "ReceivedExtensions.Received(Of Func(Of Foo))(substitute, Quantity.None())",
+        "ReceivedExtensions.Received(Of Func(Of Foo))(substitute:= substitute, requiredQuantity:= Quantity.None())",
+        "ReceivedExtensions.Received(Of Func(Of Foo))(requiredQuantity:= Quantity.None(), substitute:= substitute)",
         "SubstituteExtensions.Received(substitute)",
+        "SubstituteExtensions.Received(substitute:= substitute)",
         "SubstituteExtensions.Received(Of Func(Of Foo))(substitute)",
+        "SubstituteExtensions.Received(Of Func(Of Foo))(substitute:= substitute)",
         "ReceivedExtensions.ReceivedWithAnyArgs(substitute, Quantity.None())",
+        "ReceivedExtensions.ReceivedWithAnyArgs(substitute:= substitute, requiredQuantity:= Quantity.None())",
+        "ReceivedExtensions.ReceivedWithAnyArgs(requiredQuantity:= Quantity.None(), substitute:= substitute)",
         "ReceivedExtensions.ReceivedWithAnyArgs(Of Func(Of Foo))(substitute, Quantity.None())",
+        "ReceivedExtensions.ReceivedWithAnyArgs(Of Func(Of Foo))(substitute:= substitute, requiredQuantity:= Quantity.None())",
+        "ReceivedExtensions.ReceivedWithAnyArgs(Of Func(Of Foo))(requiredQuantity:= Quantity.None(), substitute:= substitute)",
         "SubstituteExtensions.ReceivedWithAnyArgs(substitute)",
+        "SubstituteExtensions.ReceivedWithAnyArgs(substitute:= substitute)",
         "SubstituteExtensions.ReceivedWithAnyArgs(Of Func(Of Foo))(substitute)",
+        "SubstituteExtensions.ReceivedWithAnyArgs(Of Func(Of Foo))(substitute:= substitute)",
         "SubstituteExtensions.DidNotReceive(substitute)",
+        "SubstituteExtensions.DidNotReceive(substitute:= substitute)",
         "SubstituteExtensions.DidNotReceive(Of Func(Of Foo))(substitute)",
+        "SubstituteExtensions.DidNotReceive(Of Func(Of Foo))(substitute:= substitute)",
         "SubstituteExtensions.DidNotReceiveWithAnyArgs(substitute)",
-        "SubstituteExtensions.DidNotReceiveWithAnyArgs(Of Func(Of Foo))(substitute)")]
+        "SubstituteExtensions.DidNotReceiveWithAnyArgs(substitute:= substitute)",
+        "SubstituteExtensions.DidNotReceiveWithAnyArgs(Of Func(Of Foo))(substitute)",
+        "SubstituteExtensions.DidNotReceiveWithAnyArgs(Of Func(Of Foo))(substitute:= substitute)")]
     public override async Task ReportsNoDiagnostics_WhenCheckingReceivedCallsForDelegate(string method)
     {
         var source = $@"Imports NSubstitute
@@ -251,17 +282,31 @@ End Namespace
 
     [CombinatoryData(
         "ReceivedExtensions.Received(substitute, Quantity.None())",
+        "ReceivedExtensions.Received(substitute:= substitute, requiredQuantity:= Quantity.None())",
+        "ReceivedExtensions.Received(requiredQuantity:= Quantity.None(), substitute:= substitute)",
         "ReceivedExtensions.Received(Of Foo(Of Integer))(substitute, Quantity.None())",
+        "ReceivedExtensions.Received(Of Foo(Of Integer))(substitute:= substitute, requiredQuantity:= Quantity.None())",
+        "ReceivedExtensions.Received(Of Foo(Of Integer))(requiredQuantity:= Quantity.None(), substitute:= substitute)",
         "SubstituteExtensions.Received(substitute)",
+        "SubstituteExtensions.Received(substitute:= substitute)",
         "SubstituteExtensions.Received(Of Foo(Of Integer))(substitute)",
+        "SubstituteExtensions.Received(Of Foo(Of Integer))(substitute:= substitute)",
         "ReceivedExtensions.ReceivedWithAnyArgs(substitute, Quantity.None())",
-        "ReceivedExtensions.ReceivedWithAnyArgs(Of Foo(Of Integer))(substitute, Quantity.None())",
+        "ReceivedExtensions.ReceivedWithAnyArgs(substitute:= substitute, requiredQuantity:= Quantity.None())",
+        "ReceivedExtensions.ReceivedWithAnyArgs(requiredQuantity:= Quantity.None(), substitute:= substitute)",
+        "ReceivedExtensions.ReceivedWithAnyArgs(Of Foo(Of Integer))(substitute:= substitute, requiredQuantity:= Quantity.None())",
+        "ReceivedExtensions.ReceivedWithAnyArgs(Of Foo(Of Integer))(requiredQuantity:= Quantity.None(), substitute:= substitute)",
         "SubstituteExtensions.ReceivedWithAnyArgs(substitute)",
+        "SubstituteExtensions.ReceivedWithAnyArgs(substitute:= substitute)",
         "SubstituteExtensions.ReceivedWithAnyArgs(Of Foo(Of Integer))(substitute)",
+        "SubstituteExtensions.ReceivedWithAnyArgs(Of Foo(Of Integer))(substitute:= substitute)",
         "SubstituteExtensions.DidNotReceive(substitute)",
+        "SubstituteExtensions.DidNotReceive(substitute:= substitute)",
         "SubstituteExtensions.DidNotReceive(Of Foo(Of Integer))(substitute)",
+        "SubstituteExtensions.DidNotReceive(Of Foo(Of Integer))(substitute:= substitute)",
         "SubstituteExtensions.DidNotReceiveWithAnyArgs(substitute)",
-        "SubstituteExtensions.DidNotReceiveWithAnyArgs(Of Foo(Of Integer))(substitute)")]
+        "SubstituteExtensions.DidNotReceiveWithAnyArgs(substitute:= substitute)",
+        "SubstituteExtensions.DidNotReceiveWithAnyArgs(Of Foo(Of Integer))(substitute:= substitute)")]
     public override async Task ReportsNoDiagnostics_WhenCheckingReceivedCallsForGenericInterfaceMethod(string method)
     {
         var source = $@"Imports NSubstitute

--- a/tests/NSubstitute.Analyzers.Tests.VisualBasic/DiagnosticAnalyzersTests/NonSubstitutableMemberReceivedInOrderAnalyzerTests/NonSubstitutableMemberReceivedInOrderDiagnosticVerifier.cs
+++ b/tests/NSubstitute.Analyzers.Tests.VisualBasic/DiagnosticAnalyzersTests/NonSubstitutableMemberReceivedInOrderAnalyzerTests/NonSubstitutableMemberReceivedInOrderDiagnosticVerifier.cs
@@ -56,6 +56,7 @@ Namespace MyNamespace
                                  [|substitute.Bar()|]
                              End Function)
             NSubstitute.Received.InOrder(Function() [|substitute.Bar()|])
+            NSubstitute.Received.InOrder(Async Function() Await [|otherSubstitute.Bar()|])
             NSubstitute.Received.InOrder(Sub() [|substitute.Bar()|])
             NSubstitute.Received.InOrder(Function()
                                  [|substitute.Nested.Bar()|]
@@ -104,6 +105,10 @@ Namespace MyNamespace
                                  Dim y = [|substitute.Bar()|]
                                  Dim z = CInt([|substitute.Bar()|])
                                  Dim zz = TryCast([|substitute.Bar()|], Object)
+                             End Function)
+            NSubstitute.Received.InOrder(Async Function()
+                                 Await [|otherSubstitute.Bar()|]
+                                 Dim y = Await [|otherSubstitute.Bar()|]
                              End Function)
             NSubstitute.Received.InOrder(Async Function()
                                  Await [|otherSubstitute.Bar()|]
@@ -388,6 +393,9 @@ Namespace MyNamespace
                                              substitute.Bar(CType(substitute.FooBar(), Integer))
                                              substitute.Bar(local)
                                              substitute.Bar(1)
+                                         End Function)
+            NSubstitute.Received.InOrder(Async Function()
+                                             Dim x = substitute.Bar(Await otherSubstitute.Bar())
                                          End Function)
             NSubstitute.Received.InOrder(Async Function()
                                              Dim x = substitute.Bar(Await otherSubstitute.Bar())

--- a/tests/NSubstitute.Analyzers.Tests.VisualBasic/DiagnosticAnalyzersTests/NonSubstitutableMemberWhenAnalyzerTests/WhenAsOrdinaryMethodTests.cs
+++ b/tests/NSubstitute.Analyzers.Tests.VisualBasic/DiagnosticAnalyzersTests/NonSubstitutableMemberWhenAnalyzerTests/WhenAsOrdinaryMethodTests.cs
@@ -22,6 +22,8 @@ Namespace MyNamespace
             Dim i As Integer = 1
             Dim substitute = NSubstitute.Substitute.[For](Of Foo)()
             {method}(substitute,{whenAction}).[Do](Sub(callInfo) i = i + 1)
+            {method}(substitute:= substitute, substituteCall:= {whenAction}).[Do](Sub(callInfo) i = i + 1)
+            {method}(substituteCall:= {whenAction}, substitute:= substitute).[Do](Sub(callInfo) i = i + 1)
         End Sub
     End Class
 End Namespace
@@ -50,6 +52,8 @@ Namespace MyNamespace
             Dim i As Integer = 1
             Dim substitute = NSubstitute.Substitute.[For](Of Foo)()
             {method}(substitute,{whenAction}).[Do](Sub(callInfo) i = i + 1)
+            {method}(substitute:= substitute, substituteCall:= {whenAction}).[Do](Sub(callInfo) i = i + 1)
+            {method}(substituteCall:= {whenAction}, substitute:= substitute).[Do](Sub(callInfo) i = i + 1)
         End Sub
     End Class
 End Namespace";
@@ -72,7 +76,9 @@ Namespace MyNamespace
         Public Sub Test()
             Dim i As Integer = 1
             Dim substitute = NSubstitute.Substitute.[For](Of Foo)()
-            {method}(substitute,{whenAction}).[Do](Sub(callInfo) i = i + 1)
+            {method}(substitute, {whenAction}).[Do](Sub(callInfo) i = i + 1)
+            {method}(substitute:= substitute, substituteCall:= {whenAction}).[Do](Sub(callInfo) i = i + 1)
+            {method}(substituteCall:= {whenAction}, substitute:= substitute).[Do](Sub(callInfo) i = i + 1)
         End Sub
     End Class
 End Namespace
@@ -105,6 +111,8 @@ Namespace MyNamespace
             Dim i As Integer = 1
             Dim substitute = NSubstitute.Substitute.[For](Of Foo)()
             {method}(substitute,{whenAction}).[Do](Sub(callInfo) i = i + 1)
+            {method}(substitute:= substitute, substituteCall:= {whenAction}).[Do](Sub(callInfo) i = i + 1)
+            {method}(substituteCall:= {whenAction}, substitute:= substitute).[Do](Sub(callInfo) i = i + 1)
         End Sub
     End Class
 End Namespace
@@ -123,7 +131,9 @@ Namespace MyNamespace
         Public Sub Test()
             Dim i As Integer = 1
             Dim substitute = NSubstitute.Substitute.[For](Of Func(Of Integer))()
-            {method}(substitute,{whenAction}).[Do](Sub(callInfo) i = i + 1)
+            {method}(substitute, {whenAction}).[Do](Sub(callInfo) i = i + 1)
+            {method}(substitute:= substitute, substituteCall:= {whenAction}).[Do](Sub(callInfo) i = i + 1)
+            {method}(substituteCall:= {whenAction}, substitute:= substitute).[Do](Sub(callInfo) i = i + 1)
         End Sub
     End Class
 End Namespace
@@ -154,7 +164,9 @@ Namespace MyNamespace
         Public Sub Test()
             Dim i As Integer = 1
             Dim substitute = NSubstitute.Substitute.[For](Of Foo)()
-            {method}(substitute,{whenAction}).[Do](Sub(callInfo) i = i + 1)
+            {method}(substitute, {whenAction}).[Do](Sub(callInfo) i = i + 1)
+            {method}(substitute:= substitute, substituteCall:= {whenAction}).[Do](Sub(callInfo) i = i + 1)
+            {method}(substituteCall:= {whenAction}, substitute:= substitute).[Do](Sub(callInfo) i = i + 1)
         End Sub
     End Class
 End Namespace
@@ -176,6 +188,7 @@ Namespace MyNamespace
             Dim i As Integer = 1
             Dim substitute = NSubstitute.Substitute.[For](Of Foo)()
             {method}(substitute,{whenAction}).[Do](Sub(callInfo) i = i +1)
+            {method}(substitute:= substitute, substituteCall:= {whenAction}).[Do](Sub(callInfo) i = i +1)
         End Sub
     End Class
 End Namespace
@@ -197,7 +210,8 @@ Namespace MyNamespace
         Public Sub Test()
             Dim i As Integer = 1
             Dim substitute = NSubstitute.Substitute.[For](Of Foo)()
-            {method}(substitute,{whenAction}).[Do](Sub(callInfo) i = i +1)
+            {method}(substitute:= substitute, substituteCall:= {whenAction}).[Do](Sub(callInfo) i = i +1)
+            {method}(substituteCall:= {whenAction}, substitute:= substitute).[Do](Sub(callInfo) i = i +1)
         End Sub
     End Class
 End Namespace";
@@ -211,13 +225,14 @@ End Namespace";
 Namespace MyNamespace
     Interface Foo
         ReadOnly Property Bar As Integer
-    End Interface
-
+    End Interface 
     Public Class FooTests
         Public Sub Test()
             Dim i As Integer = 1
             Dim substitute = NSubstitute.Substitute.[For](Of Foo)()
-            {method}(substitute,{whenAction}).[Do](Sub(callInfo) i = i + 1)
+            {method}(substitute, {whenAction}).[Do](Sub(callInfo) i = i + 1)
+            {method}(substitute: =substitute, substituteCall:= {whenAction}).[Do](Sub(callInfo) i = i + 1)
+            {method}(substituteCall:= {whenAction}, substitute:= substitute).[Do](Sub(callInfo) i = i + 1)
         End Sub
     End Class
 End Namespace
@@ -242,7 +257,9 @@ Namespace MyNamespace
     Public Sub Test()
             Dim i As Integer = 1
             Dim substitute = NSubstitute.Substitute.[For](Of Foo (Of Integer))()
-            {method}(substitute,{whenAction}).[Do](Sub(callInfo) i = i + 1)
+            {method}(substitute, {whenAction}).[Do](Sub(callInfo) i = i + 1)
+            {method}(substitute:= substitute, substituteCall:= {whenAction}).[Do](Sub(callInfo) i = i + 1)
+            {method}(substituteCall:= {whenAction}, substitute:= substitute).[Do](Sub(callInfo) i = i + 1)
         End Sub
     End Class
 End Namespace";
@@ -262,7 +279,9 @@ Namespace MyNamespace
         Public Sub Test()
             Dim i As Integer = 1
             Dim substitute = NSubstitute.Substitute.[For](Of Foo)()
-            {method}(substitute,{whenAction}).[Do](Sub(callInfo) i = i + 1)
+            {method}(substitute, {whenAction}).[Do](Sub(callInfo) i = i + 1)
+            {method}(substitute:= substitute, substituteCall:= {whenAction}).[Do](Sub(callInfo) i = i + 1)
+            {method}(substituteCall:= {whenAction}, substitute:= substitute).[Do](Sub(callInfo) i = i + 1)
         End Sub
     End Class
 End Namespace
@@ -284,7 +303,9 @@ Namespace MyNamespace
         Public Sub Test()
             Dim i As Integer = 1
             Dim substitute = NSubstitute.Substitute.[For](Of Foo)()
-            {method}(substitute,{whenAction}).[Do](Sub(callInfo) i = i + 1)
+            {method}(substitute, {whenAction}).[Do](Sub(callInfo) i = i + 1)
+            {method}(substitute:= substitute, substituteCall:= {whenAction}).[Do](Sub(callInfo) i = i + 1)
+            {method}(substituteCall:= {whenAction}, substitute:= substitute).[Do](Sub(callInfo) i = i + 1)
         End Sub
     End Class
 End Namespace
@@ -339,7 +360,9 @@ Namespace MyNamespace
         Public Sub Test()
             Dim i As Integer = 1
             Dim substitute = NSubstitute.Substitute.[For](Of Foo)()
-            {method}(substitute,{whenAction}).[Do](Sub(callInfo) i = i + 1)
+            {method}(substitute, {whenAction}).[Do](Sub(callInfo) i = i + 1)
+            {method}(substitute:= substitute, substituteCall:= {whenAction}).[Do](Sub(callInfo) i = i + 1)
+            {method}(substituteCall:= {whenAction}, substitute:= substitute).[Do](Sub(callInfo) i = i + 1)
         End Sub
     End Class
 End Namespace
@@ -360,7 +383,9 @@ Namespace MyNamespace
         Public Sub Test()
             Dim i As Integer = 1
             Dim substitute = NSubstitute.Substitute.[For](Of Foo)()
-            {method}(substitute,{whenAction}).[Do](Sub(callInfo) i = i + 1)
+            {method}(substitute, {whenAction}).[Do](Sub(callInfo) i = i + 1)
+            {method}(substitute:= substitute, substituteCall:= {whenAction}).[Do](Sub(callInfo) i = i + 1)
+            {method}(substituteCall:= {whenAction}, substitute:= substitute).[Do](Sub(callInfo) i = i + 1)
         End Sub
     End Class
 End Namespace
@@ -387,7 +412,9 @@ Namespace MyNamespace
         Public Sub Test()
             Dim i As Integer = 1
             Dim substitute = NSubstitute.Substitute.[For](Of Foo)()
-            {method}(substitute,{whenAction}).[Do](Sub(callInfo) i = i + 1)
+            {method}(substitute, {whenAction}).[Do](Sub(callInfo) i = i + 1)
+            {method}(substitute:= substitute, substituteCall:= {whenAction}).[Do](Sub(callInfo) i = i + 1)
+            {method}(substituteCall:= {whenAction}, substitute:= substitute).[Do](Sub(callInfo) i = i + 1)
         End Sub
     End Class
 End Namespace
@@ -410,11 +437,21 @@ Namespace MyNamespace
         Public Sub Test()
             Dim i As Integer = 0
             Dim substitute = NSubstitute.Substitute.[For](Of Foo)()
-            {method}(substitute,AddressOf SubstituteCall).[Do](Sub(callInfo) i = i + 1)
+            {method}(substitute, AddressOf SubstituteCall).[Do](Sub(callInfo) i = i + 1)
+            {method}(substitute:= substitute, substituteCall:= AddressOf OtherSubstituteCall).[Do](Sub(callInfo) i = i + 1)
+            {method}(substituteCall:= AddressOf YetAnotherSubstituteCall, substitute:= substitute).[Do](Sub(callInfo) i = i + 1)
             substitute.Bar(1)
         End Sub
 
         Private Sub SubstituteCall(ByVal [sub] As Foo)
+            Dim objBarr = [|[sub].Bar(Arg.Any(Of Integer)())|]
+        End Sub
+
+        Private Sub OtherSubstituteCall(ByVal [sub] As Foo)
+            Dim objBarr = [|[sub].Bar(Arg.Any(Of Integer)())|]
+        End Sub
+
+        Private Sub YetAnotherSubstituteCall(ByVal [sub] As Foo)
             Dim objBarr = [|[sub].Bar(Arg.Any(Of Integer)())|]
         End Sub
     End Class
@@ -439,6 +476,8 @@ Namespace MyNamespace
             Dim i As Integer = 0
             Dim substitute = NSubstitute.Substitute.[For](Of Foo)()
             {method}(substitute,AddressOf SubstituteCall).[Do](Sub(callInfo) i = i + 1)
+            {method}(substitute:= substitute, substituteCall:= AddressOf SubstituteCall).[Do](Sub(callInfo) i = i + 1)
+            {method}(substituteCall:= AddressOf SubstituteCall, substitute:= substitute).[Do](Sub(callInfo) i = i + 1)
             substitute.Bar(1)
         End Sub
 
@@ -476,6 +515,8 @@ Namespace MyNamespace
             Dim i As Integer = 0
             Dim substitute = NSubstitute.Substitute.[For](Of Foo)()
             {method}(substitute, {call}).[Do](Sub(callInfo) i = i + 1)
+            {method}(substitute:= substitute, substituteCall:= {call}).[Do](Sub(callInfo) i = i + 1)
+            {method}(substituteCall:= {call}, substitute:= substitute).[Do](Sub(callInfo) i = i + 1)
         End Sub
     End Class
 End Namespace";
@@ -511,6 +552,8 @@ Namespace MyNamespace
             Dim i As Integer = 0
             Dim substitute = NSubstitute.Substitute.[For](Of Foo)()
             {method}(substitute, {call}).[Do](Sub(callInfo) i = i + 1)
+            {method}(substitute:= substitute, substituteCall:= {call}).[Do](Sub(callInfo) i = i + 1)
+            {method}(substituteCall:= {call}, substitute:= substitute).[Do](Sub(callInfo) i = i + 1)
         End Sub
     End Class
 End Namespace";
@@ -544,6 +587,8 @@ Namespace MyNamespace
             Dim i As Integer = 0
             Dim substitute = NSubstitute.Substitute.[For](Of Foo)()
             {method}(substitute, {call}).[Do](Sub(callInfo) i = i + 1)
+            {method}(substitute:= substitute, substituteCall:= {call}).[Do](Sub(callInfo) i = i + 1)
+            {method}(substituteCall:= {call}, substitute:= substitute).[Do](Sub(callInfo) i = i + 1)
         End Sub
     End Class
 End Namespace";
@@ -575,6 +620,8 @@ Namespace MyNamespace
             Dim i As Integer = 0
             Dim substitute = NSubstitute.Substitute.[For](Of Foo)()
             {method}(substitute, {call}).[Do](Sub(callInfo) i = i + 1)
+            {method}(substitute:= substitute, substituteCall:= {call}).[Do](Sub(callInfo) i = i + 1)
+            {method}(substituteCall:= {call}, substitute:= substitute).[Do](Sub(callInfo) i = i + 1)
         End Sub
     End Class
 End Namespace";


### PR DESCRIPTION
Using IOperation API for 
```
NonSubstitutableMemberAnalyzer
NonSubstitutableMemberReceivedAnalyzer
NonSubstitutableMemberReceivedInOrderAnalyzer
NonSubstitutableMemberWhenAnalyzer
ReceivedInReceivedInOrderAnalyzer
CallInfoAnalyzer
```
to handle out of order named parameters as well to simplify code