### PR TITLE
GH-213 - do not report NS1004 when arg matcher is used directly in return statement

### DIFF
--- a/src/NSubstitute.Analyzers.Shared/DiagnosticAnalyzers/AbstractNonSubstitutableMemberArgumentMatcherAnalyzer.cs
+++ b/src/NSubstitute.Analyzers.Shared/DiagnosticAnalyzers/AbstractNonSubstitutableMemberArgumentMatcherAnalyzer.cs
@@ -20,7 +20,7 @@ internal abstract class AbstractNonSubstitutableMemberArgumentMatcherAnalyzer : 
         OperationKind.SimpleAssignment);
 
     private static readonly ImmutableHashSet<OperationKind> IgnoredAncestors =
-        ImmutableHashSet.Create(OperationKind.VariableDeclarator, OperationKind.VariableDeclaration);
+        ImmutableHashSet.Create(OperationKind.VariableDeclarator, OperationKind.VariableDeclaration, OperationKind.Return);
 
     private static readonly ImmutableHashSet<OperationKind> DynamicOperations =
         ImmutableHashSet.Create(OperationKind.DynamicInvocation, OperationKind.DynamicIndexerAccess, OperationKind.DynamicMemberReference);

--- a/tests/NSubstitute.Analyzers.Tests.CSharp/DiagnosticAnalyzerTests/NonSubstitutableMemberArgumentMatcherAnalyzerTests/NonSubstitutableMemberArgumentMatcherDiagnosticVerifier.cs
+++ b/tests/NSubstitute.Analyzers.Tests.CSharp/DiagnosticAnalyzerTests/NonSubstitutableMemberArgumentMatcherAnalyzerTests/NonSubstitutableMemberArgumentMatcherDiagnosticVerifier.cs
@@ -135,6 +135,10 @@ public abstract class NonSubstitutableMemberArgumentMatcherDiagnosticVerifier : 
     [MemberData(nameof(CorrectlyUsedArgTestCasesWithoutDelegates))]
     public abstract Task ReportsDiagnostics_WhenAssigningInvalidArgMatchersToMemberPrecededByWithAnyArgsLikeMethod(string receivedMethod, string arg);
 
+    [CombinatoryTheory]
+    [MemberData(nameof(CorrectlyUsedArgTestCasesWithoutDelegates))]
+    public abstract Task ReportsNoDiagnostics_WhenUsedDirectlyWithReturnStatement(string arg);
+
     public static IEnumerable<object[]> MisusedArgTestCases
     {
         get

--- a/tests/NSubstitute.Analyzers.Tests.CSharp/DiagnosticAnalyzerTests/NonSubstitutableMemberArgumentMatcherAnalyzerTests/NonSubstitutableMemberArgumentMatcherTests.cs
+++ b/tests/NSubstitute.Analyzers.Tests.CSharp/DiagnosticAnalyzerTests/NonSubstitutableMemberArgumentMatcherAnalyzerTests/NonSubstitutableMemberArgumentMatcherTests.cs
@@ -1003,4 +1003,34 @@ namespace MyNamespace
 }}";
         await VerifyNoDiagnostic(source);
     }
+
+    public override async Task ReportsNoDiagnostics_WhenUsedDirectlyWithReturnStatement(string arg)
+    {
+        var source = $@"using System;
+using NSubstitute;
+using NSubstitute.ReceivedExtensions;
+
+namespace MyNamespace
+{{
+    public interface IFoo
+    {{
+        int Bar(int? x);
+    }}
+
+    public class FooTests
+    {{
+        public void Test()
+        {{
+            var substitute = Substitute.For<IFoo>();
+            substitute.Received(1).Bar(MatchesArg());
+        }}
+
+        private int? MatchesArg()
+        {{
+            return {arg};
+        }}
+    }}
+}}";
+        await VerifyNoDiagnostic(source);
+    }
 }

--- a/tests/NSubstitute.Analyzers.Tests.Shared/DiagnosticAnalyzers/INonSubstitutableMemberArgumentMatcherDiagnosticVerifier.cs
+++ b/tests/NSubstitute.Analyzers.Tests.Shared/DiagnosticAnalyzers/INonSubstitutableMemberArgumentMatcherDiagnosticVerifier.cs
@@ -59,4 +59,6 @@ public interface INonSubstitutableMemberArgumentMatcherDiagnosticVerifier
     Task ReportsDiagnostics_WhenAssigningArgMatchersToNonSubstitutableMember_InWhenLikeMethod(string whenMethod, string arg);
 
     Task ReportsNoDiagnostics_WhenAssigningArgMatchersToSubstitutableMember_InWhenLikeMethod(string whenMethod, string arg);
+
+    Task ReportsNoDiagnostics_WhenUsedDirectlyWithReturnStatement(string arg);
 }

--- a/tests/NSubstitute.Analyzers.Tests.VisualBasic/DiagnosticAnalyzersTests/NonSubstitutableMemberArgumentMatcherAnalyzerTests/NonSubstitutableMemberArgumentMatcherDiagnosticVerifier.cs
+++ b/tests/NSubstitute.Analyzers.Tests.VisualBasic/DiagnosticAnalyzersTests/NonSubstitutableMemberArgumentMatcherAnalyzerTests/NonSubstitutableMemberArgumentMatcherDiagnosticVerifier.cs
@@ -139,6 +139,10 @@ public abstract class NonSubstitutableMemberArgumentMatcherDiagnosticVerifier : 
     [Fact]
     public abstract Task ReportsNoDiagnostic_WhenOverloadCannotBeInferred();
 
+    [CombinatoryTheory]
+    [MemberData(nameof(CorrectlyUsedArgTestCasesWithoutDelegates))]
+    public abstract Task ReportsNoDiagnostics_WhenUsedDirectlyWithReturnStatement(string arg);
+
     public static IEnumerable<object[]> MisusedArgTestCases
     {
         get { return MisusedArgs.Select(argArray => argArray.Select<string, object>(arg => arg).ToArray()); }

--- a/tests/NSubstitute.Analyzers.Tests.VisualBasic/DiagnosticAnalyzersTests/NonSubstitutableMemberArgumentMatcherAnalyzerTests/NonSubstitutableMemberArgumentMatcherTests.cs
+++ b/tests/NSubstitute.Analyzers.Tests.VisualBasic/DiagnosticAnalyzersTests/NonSubstitutableMemberArgumentMatcherAnalyzerTests/NonSubstitutableMemberArgumentMatcherTests.cs
@@ -1017,4 +1017,30 @@ End Namespace
 
         await VerifyNoDiagnostic(source);
     }
+
+    public override async Task ReportsNoDiagnostics_WhenUsedDirectlyWithReturnStatement(string arg)
+    {
+        var source = @"Imports System
+Imports NSubstitute
+Imports NSubstitute.ReceivedExtensions
+
+Namespace MyNamespace
+    Interface IFoo
+        Function Bar(ByVal x As Integer?) As Integer
+    End Interface
+
+    Public Class FooTests
+        Public Sub Test()
+            Dim substitute = NSubstitute.Substitute.[For](Of IFoo)()
+            substitute.Received(1).Bar(MatchesArg())
+        End Sub
+
+        Private Function MatchesArg() As Integer?
+            Return Arg.Any(Of Integer)()
+        End Function
+    End Class
+End Namespace
+";
+        await VerifyNoDiagnostic(source);
+    }
 }


### PR DESCRIPTION
Closes #213 